### PR TITLE
Add `GCVPoint` class corresponding to `cv::Point`

### DIFF
--- a/doc/reference/opencv-glib-docs.xml
+++ b/doc/reference/opencv-glib-docs.xml
@@ -23,6 +23,7 @@
     <xi:include href="xml/color.xml"/>
     <xi:include href="xml/image.xml"/>
     <xi:include href="xml/matrix.xml"/>
+    <xi:include href="xml/point.xml"/>
     <xi:include href="xml/rectangle.xml"/>
   </chapter>
 

--- a/opencv-glib/meson.build
+++ b/opencv-glib/meson.build
@@ -7,6 +7,7 @@ sources = files(
   'image.cpp',
   'image-error.cpp',
   'matrix.cpp',
+  'point.cpp',
   'rectangle.cpp',
   'video-capture.cpp',
 )
@@ -21,6 +22,7 @@ c_headers = files(
   'image-error.h',
   'matrix.h',
   'opencv-glib.h',
+  'point.h',
   'rectangle.h',
   'video-capture.h',
 )
@@ -32,6 +34,7 @@ cpp_headers = files(
   'image.hpp',
   'matrix.hpp',
   'opencv-glib.hpp',
+  'point.hpp',
   'rectangle.hpp',
   'video-capture.hpp',
 )

--- a/opencv-glib/opencv-glib.h
+++ b/opencv-glib/opencv-glib.h
@@ -9,5 +9,6 @@
 #include <opencv-glib/image.h>
 #include <opencv-glib/image-error.h>
 #include <opencv-glib/matrix.h>
+#include <opencv-glib/point.h>
 #include <opencv-glib/rectangle.h>
 #include <opencv-glib/video-capture.h>

--- a/opencv-glib/point.cpp
+++ b/opencv-glib/point.cpp
@@ -1,0 +1,186 @@
+#include <opencv-glib/point.hpp>
+
+G_BEGIN_DECLS
+
+/**
+ * SECTION: point
+ * @title: Point class
+ * @include: opencv-glib/opencv-glib.h
+ *
+ * #GCVPoint is a point class.
+ *
+ * Since: 1.0.1
+ */
+
+typedef struct {
+  std::shared_ptr<cv::Point> point;
+} GCVPointPrivate;
+
+G_DEFINE_TYPE_WITH_PRIVATE(GCVPoint, gcv_point, G_TYPE_OBJECT)
+
+#define GCV_POINT_GET_PRIVATE(obj)                     \
+  (G_TYPE_INSTANCE_GET_PRIVATE((obj),                  \
+                               GCV_TYPE_POINT,         \
+                               GCVPointPrivate))
+
+enum {
+  PROP_POINT = 1
+};
+
+static void
+gcv_point_finalize(GObject *object)
+{
+  auto priv = GCV_POINT_GET_PRIVATE(object);
+
+  priv->point = nullptr;
+
+  G_OBJECT_CLASS(gcv_point_parent_class)->finalize(object);
+}
+
+static void
+gcv_point_set_property(GObject *object,
+                       guint prop_id,
+                       const GValue *value,
+                       GParamSpec *pspec)
+{
+  auto priv = GCV_POINT_GET_PRIVATE(object);
+
+  switch (prop_id) {
+  case PROP_POINT:
+    priv->point =
+      *static_cast<std::shared_ptr<cv::Point> *>(g_value_get_pointer(value));
+    break;
+  default:
+    G_OBJECT_WARN_INVALID_PROPERTY_ID(object, prop_id, pspec);
+    break;
+  }
+}
+
+static void
+gcv_point_init(GCVPoint *object)
+{
+}
+
+static void
+gcv_point_class_init(GCVPointClass *klass)
+{
+  GParamSpec *spec;
+
+  auto gobject_class = G_OBJECT_CLASS(klass);
+
+  gobject_class->finalize     = gcv_point_finalize;
+  gobject_class->set_property = gcv_point_set_property;
+
+  spec = g_param_spec_pointer("point",
+                              "Point",
+                              "The raw std::shared<cv::Point> *",
+                              static_cast<GParamFlags>(G_PARAM_WRITABLE |
+                                                       G_PARAM_CONSTRUCT_ONLY));
+  g_object_class_install_property(gobject_class, PROP_POINT, spec);
+}
+
+/**
+ * gcv_point_new:
+ * @x: A X value of the point
+ * @y: A Y value of the point
+ *
+ * Returns: A newly created #GCVPoint.
+ *
+ * Since: 1.0.1
+ */
+GCVPoint *
+gcv_point_new(gint x, gint y)
+{
+  auto cv_point = std::make_shared<cv::Point>(x, y);
+  return gcv_point_new_raw(&cv_point);
+}
+
+/**
+ * gcv_point_new_empty:
+ *
+ * Returns: A newly created empty #GCVPoint.
+ *
+ * Since: 1.0.1
+ */
+GCVPoint *
+gcv_point_new_empty(void)
+{
+  auto cv_point = std::make_shared<cv::Point>();
+  return gcv_point_new_raw(&cv_point);
+}
+
+/**
+ * gcv_point_get_x:
+ * @point: A #GCVPoint
+ *
+ * Returns: The X value of the point.
+ *
+ * Since: 1.0.1
+ */
+gint
+gcv_point_get_x(GCVPoint *point)
+{
+  auto cv_point = gcv_point_get_raw(point);
+  return cv_point->x;
+}
+
+/**
+ * gcv_point_set_x:
+ * @point: A #GCVPoint
+ * @x: A new X value of the point.
+ *
+ * Since: 1.0.1
+ */
+void
+gcv_point_set_x(GCVPoint *point, gint x)
+{
+  auto cv_point = gcv_point_get_raw(point);
+  cv_point->x = x;
+}
+
+/**
+ * gcv_point_get_y:
+ * @point: A #GCVPoint
+ *
+ * Returns: The Y value of the point.
+ *
+ * Since: 1.0.1
+ */
+gint
+gcv_point_get_y(GCVPoint *point)
+{
+  auto cv_point = gcv_point_get_raw(point);
+  return cv_point->y;
+}
+
+/**
+ * gcv_point_set_y:
+ * @point: A #GCVPoint
+ * @y: A new Y value of the point.
+ *
+ * Since: 1.0.1
+ */
+void
+gcv_point_set_y(GCVPoint *point, gint y)
+{
+  auto cv_point = gcv_point_get_raw(point);
+  cv_point->y = y;
+}
+
+G_END_DECLS
+
+GCVPoint *
+gcv_point_new_raw(std::shared_ptr<cv::Point> *cv_point)
+{
+  auto point = g_object_new(GCV_TYPE_POINT,
+                            "point", cv_point,
+                            NULL);
+  return GCV_POINT(point);
+}
+
+std::shared_ptr<cv::Point>
+gcv_point_get_raw(GCVPoint *point)
+{
+  auto priv = GCV_POINT_GET_PRIVATE(point);
+  return priv->point;
+}

--- a/opencv-glib/point.h
+++ b/opencv-glib/point.h
@@ -1,0 +1,26 @@
+#pragma once
+
+#include <glib-object.h>
+
+G_BEGIN_DECLS
+
+#define GCV_TYPE_POINT (gcv_point_get_type())
+G_DECLARE_DERIVABLE_TYPE(GCVPoint,
+                         gcv_point,
+                         GCV,
+                         POINT,
+                         GObject)
+struct _GCVPointClass
+{
+  GObjectClass parent_class;
+};
+
+GCVPoint *gcv_point_new(gint x, gint y);
+GCVPoint *gcv_point_new_empty(void);
+
+gint gcv_point_get_x(GCVPoint *point);
+void gcv_point_set_x(GCVPoint *point, gint x);
+gint gcv_point_get_y(GCVPoint *point);
+void gcv_point_set_y(GCVPoint *point, gint y);
+
+G_END_DECLS

--- a/opencv-glib/point.hpp
+++ b/opencv-glib/point.hpp
@@ -1,0 +1,10 @@
+#pragma once
+
+#include <memory>
+
+#include <opencv2/core/types.hpp>
+
+#include <opencv-glib/point.h>
+
+GCVPoint *gcv_point_new_raw(std::shared_ptr<cv::Point> *cv_point);
+std::shared_ptr<cv::Point> gcv_point_get_raw(GCVPoint *point);

--- a/test/test-point.rb
+++ b/test/test-point.rb
@@ -1,0 +1,21 @@
+class TestPoint < Test::Unit::TestCase
+  sub_test_case(".new") do
+    def test_empty
+      point = CV::Point.new
+      assert_equal([0, 0],
+                   [
+                     point.x,
+                     point.y,
+                   ])
+    end
+
+    def test_x_and_y
+      point = CV::Point.new(1, 2)
+      assert_equal([1, 2],
+                   [
+                     point.x,
+                     point.y,
+                   ])
+    end
+  end
+end


### PR DESCRIPTION
Implementation of `GCVPoint` class. It will be required to implement some drawing functions. For example, `gcv_draw_circle()`, `gcv_draw_line()`, etc.

And I have one question. Should `point.h` be included from `opencv-glib.h`? Now it includes all glib API's public header files.
