### PR TITLE
Add drawing functions with point

### DIFF
--- a/opencv-glib/image.cpp
+++ b/opencv-glib/image.cpp
@@ -2,6 +2,7 @@
 #include <opencv-glib/enums.h>
 #include <opencv-glib/image.hpp>
 #include <opencv-glib/image-error.h>
+#include <opencv-glib/point.hpp>
 #include <opencv-glib/rectangle.hpp>
 
 #include <opencv2/imgproc.hpp>
@@ -240,6 +241,45 @@ gcv_image_convert_color(GCVImage *image,
                *cv_converted_image,
                static_cast<int>(code));
   return gcv_image_new_raw(&cv_converted_image);
+}
+
+/**
+ * gcv_image_draw_circle:
+ * @image: A #GCVImage.
+ * @center: A #GCVPoint to specify center.
+ * @radius: The radius of the circle.
+ * @color: A #GCVColor to specify line color.
+ * @drawing_options: (nullable): A #GCVDrawingOptions to specify optional parameters.
+ *
+ * It draws a circle with a given @center point, @radius, @color color and @drawing_options options.
+ *
+ * Since: 1.0.1
+ */
+void
+gcv_image_draw_circle(GCVImage *image,
+                      GCVPoint *center,
+                      gint radius,
+                      GCVColor *color,
+                      GCVDrawingOptions *drawing_options)
+{
+  auto cv_image = gcv_matrix_get_raw(GCV_MATRIX(image));
+  auto cv_center = gcv_point_get_raw(center);
+  auto cv_color = gcv_color_get_raw(color);
+  if (drawing_options) {
+    auto options_priv = GCV_DRAWING_OPTIONS_GET_PRIVATE(drawing_options);
+    cv::circle(*cv_image,
+               *cv_center,
+               radius,
+               *cv_color,
+               options_priv->thickness,
+               options_priv->line_type,
+               options_priv->shift);
+  } else {
+    cv::circle(*cv_image,
+               *cv_center,
+               radius,
+               *cv_color);
+  }
 }
 
 /**

--- a/opencv-glib/image.cpp
+++ b/opencv-glib/image.cpp
@@ -357,6 +357,46 @@ gcv_image_draw_rectangle(GCVImage *image,
   }
 }
 
+/**
+ * gcv_image_draw_rectangle_points:
+ * @image: A #GCVImage.
+ * @point1: A #GCVPoint to specify the vertex of the rectangle.
+ * @point2: A #GCVPoint to specify the vertex of the rectangle opposite to @point1.
+ * @color: A #GCVColor to specify line color.
+ * @drawing_options: (nullable): A #GCVDrawingOptions to specify optional parameters.
+ *
+ * It draws a rectangle whose two opposite corners are @point1 and @point2.
+ *
+ * Since: 1.0.1
+ */
+void
+gcv_image_draw_rectangle_points(GCVImage *image,
+                                GCVPoint *point1,
+                                GCVPoint *point2,
+                                GCVColor *color,
+                                GCVDrawingOptions *drawing_options)
+{
+  auto cv_image = gcv_matrix_get_raw(GCV_MATRIX(image));
+  auto cv_point1 = gcv_point_get_raw(point1);
+  auto cv_point2 = gcv_point_get_raw(point2);
+  auto cv_color = gcv_color_get_raw(color);
+  if (drawing_options) {
+    auto options_priv = GCV_DRAWING_OPTIONS_GET_PRIVATE(drawing_options);
+    cv::rectangle(*cv_image,
+                  *cv_point1,
+                  *cv_point2,
+                  *cv_color,
+                  options_priv->thickness,
+                  options_priv->line_type,
+                  options_priv->shift);
+  } else {
+    cv::rectangle(*cv_image,
+                  *cv_point1,
+                  *cv_point2,
+                  *cv_color);
+  }
+}
+
 G_END_DECLS
 
 GCVImage *

--- a/opencv-glib/image.cpp
+++ b/opencv-glib/image.cpp
@@ -283,6 +283,46 @@ gcv_image_draw_circle(GCVImage *image,
 }
 
 /**
+ * gcv_image_draw_line:
+ * @image: A #GCVImage.
+ * @point1: A #GCVPoint to specify the first point of the line segment.
+ * @point2: A #GCVPoint to specify the second point of the line segment.
+ * @color: A #GCVColor to specify line color.
+ * @drawing_options: (nullable): A #GCVDrawingOptions to specify optional parameters.
+ *
+ * It draws a line segment between @point1 and @point2 with @color color and @drawing_options options.
+ *
+ * Since: 1.0.1
+ */
+void
+gcv_image_draw_line(GCVImage *image,
+                    GCVPoint *point1,
+                    GCVPoint *point2,
+                    GCVColor *color,
+                    GCVDrawingOptions *drawing_options)
+{
+  auto cv_image = gcv_matrix_get_raw(GCV_MATRIX(image));
+  auto cv_point1 = gcv_point_get_raw(point1);
+  auto cv_point2 = gcv_point_get_raw(point2);
+  auto cv_color = gcv_color_get_raw(color);
+  if (drawing_options) {
+    auto options_priv = GCV_DRAWING_OPTIONS_GET_PRIVATE(drawing_options);
+    cv::line(*cv_image,
+             *cv_point1,
+             *cv_point2,
+             *cv_color,
+             options_priv->thickness,
+             options_priv->line_type,
+             options_priv->shift);
+  } else {
+    cv::line(*cv_image,
+             *cv_point1,
+             *cv_point2,
+             *cv_color);
+  }
+}
+
+/**
  * gcv_image_draw_rectangle:
  * @image: A #GCVImage.
  * @rectangle: A #GCVRectangle to specify area.

--- a/opencv-glib/image.h
+++ b/opencv-glib/image.h
@@ -121,6 +121,11 @@ void gcv_image_draw_circle(GCVImage *image,
                            gint radius,
                            GCVColor *color,
                            GCVDrawingOptions *drawing_options);
+void gcv_image_draw_line(GCVImage *image,
+                         GCVPoint *point1,
+                         GCVPoint *point2,
+                         GCVColor *color,
+                         GCVDrawingOptions *drawing_options);
 void gcv_image_draw_rectangle(GCVImage *image,
                               GCVRectangle *rectangle,
                               GCVColor *color,

--- a/opencv-glib/image.h
+++ b/opencv-glib/image.h
@@ -2,6 +2,7 @@
 
 #include <opencv-glib/color.h>
 #include <opencv-glib/matrix.h>
+#include <opencv-glib/point.h>
 #include <opencv-glib/rectangle.h>
 
 G_BEGIN_DECLS
@@ -115,6 +116,11 @@ gboolean gcv_image_write(GCVImage *image,
 
 GCVImage *gcv_image_convert_color(GCVImage *image,
                                   GCVColorConversionCode code);
+void gcv_image_draw_circle(GCVImage *image,
+                           GCVPoint *center,
+                           gint radius,
+                           GCVColor *color,
+                           GCVDrawingOptions *drawing_options);
 void gcv_image_draw_rectangle(GCVImage *image,
                               GCVRectangle *rectangle,
                               GCVColor *color,

--- a/opencv-glib/image.h
+++ b/opencv-glib/image.h
@@ -130,5 +130,10 @@ void gcv_image_draw_rectangle(GCVImage *image,
                               GCVRectangle *rectangle,
                               GCVColor *color,
                               GCVDrawingOptions *drawing_options);
+void gcv_image_draw_rectangle_points(GCVImage *image,
+                                     GCVPoint *point1,
+                                     GCVPoint *point2,
+                                     GCVColor *color,
+                                     GCVDrawingOptions *drawing_options);
 
 G_END_DECLS

--- a/test/test-image.rb
+++ b/test/test-image.rb
@@ -72,6 +72,34 @@ class TestImage < Test::Unit::TestCase
       end
     end
 
+    sub_test_case("#circle") do
+      def test_simple
+        cloned_image = @image.clone
+        @image.draw_circle(CV::Point.new(16, 16),
+                           10,
+                           CV::Color.new(255, 127, 0, 2))
+        assert_not_equal(cloned_image.bytes.to_s,
+                         @image.bytes.to_s)
+      end
+
+      def test_drawing_options
+        cloned_image = @image.clone
+        point = CV::Point.new(16, 16)
+        color = CV::Color.new(255, 127, 0, 2)
+        drawing_options = CV::DrawingOptions.new
+        drawing_options.thickness = 5
+        drawing_options.line_type = :line_aa
+        drawing_options.shift = 2
+        cloned_image.draw_circle(point, 10, color) # draw without options
+        @image.draw_circle(point,
+                           10,
+                           color,
+                           drawing_options) # draw with options
+        assert_not_equal(cloned_image.bytes.to_s,
+                         @image.bytes.to_s)
+      end
+    end
+
     sub_test_case("#rectangle") do
       def test_simple
         cloned_image = @image.clone

--- a/test/test-image.rb
+++ b/test/test-image.rb
@@ -100,6 +100,35 @@ class TestImage < Test::Unit::TestCase
       end
     end
 
+    sub_test_case("#line") do
+      def test_simple
+        cloned_image = @image.clone
+        @image.draw_line(CV::Point.new(10, 10),
+                         CV::Point.new(30, 20),
+                         CV::Color.new(255, 127, 0, 2))
+        assert_not_equal(cloned_image.bytes.to_s,
+                         @image.bytes.to_s)
+      end
+
+      def test_drawing_options
+        cloned_image = @image.clone
+        point1 = CV::Point.new(10, 10)
+        point2 = CV::Point.new(30, 20)
+        color = CV::Color.new(255, 127, 0, 2)
+        drawing_options = CV::DrawingOptions.new
+        drawing_options.thickness = 5
+        drawing_options.line_type = :line_aa
+        drawing_options.shift = 2
+        cloned_image.draw_line(point1, point2, color) # draw without options
+        @image.draw_line(point1,
+                         point2,
+                         color,
+                         drawing_options) # draw with options
+        assert_not_equal(cloned_image.bytes.to_s,
+                         @image.bytes.to_s)
+      end
+    end
+
     sub_test_case("#rectangle") do
       def test_simple
         cloned_image = @image.clone

--- a/test/test-image.rb
+++ b/test/test-image.rb
@@ -154,5 +154,39 @@ class TestImage < Test::Unit::TestCase
                          @image.bytes.to_s)
       end
     end
+
+    sub_test_case("#rectangle with points") do
+      def test_simple
+        cloned_image = @image.clone
+        color = CV::Color.new(255, 127, 0, 2)
+        cloned_image.draw_rectangle(CV::Rectangle.new(5, 10, 11, 11),
+                                    color) # draw with rectangle
+        @image.draw_rectangle_points(CV::Point.new(5, 10),
+                                     CV::Point.new(15, 20),
+                                     color) # draw with points
+        assert_equal(cloned_image.bytes.to_s,
+                     @image.bytes.to_s)
+      end
+
+      def test_drawing_options
+        cloned_image = @image.clone
+        point1 = CV::Point.new(5, 10)
+        point2 = CV::Point.new(15, 20)
+        color = CV::Color.new(255, 127, 0, 2)
+        drawing_options = CV::DrawingOptions.new
+        drawing_options.thickness = 5
+        drawing_options.line_type = :line_aa
+        drawing_options.shift = 2
+        cloned_image.draw_rectangle_points(point1,
+                                           point2,
+                                           color) # draw without options
+        @image.draw_rectangle_points(point1,
+                                     point2,
+                                     color,
+                                     drawing_options) # draw with options
+        assert_not_equal(cloned_image.bytes.to_s,
+                         @image.bytes.to_s)
+      end
+    end
   end
 end


### PR DESCRIPTION
Added 3 drawing functions which take `GCVPoint` as their arguments.
* `gcv_image_draw_circle()`
* `gcv_image_draw_line()`
* `gcv_image_draw_rectangle_points()`

And here is my question.

Now we set "Since 1.0.1" to newly created classes/functions/types. However, [version 1.0.1](https://github.com/red-data-tools/opencv-glib/releases/tag/1.0.1) was already released on 27 Jun 2018. Is it really ok to mark "Since 1.0.1" for them?
