### PR TITLE
Add drawing functions with additional options

### DIFF
--- a/opencv-glib/image.cpp
+++ b/opencv-glib/image.cpp
@@ -20,13 +20,13 @@ G_BEGIN_DECLS
  */
 
 typedef struct {
-  gint thickness;
   GCVLineType line_type;
-  gint shift;
-  gdouble tip_length;
-  gboolean bottom_left_origin;
-  GCVMarkerType marker_type;
   gint marker_size;
+  GCVMarkerType marker_type;
+  gint shift;
+  gint thickness;
+  gdouble tip_length;
+  gboolean use_bottom_left_origin;
 } GCVDrawingOptionsPrivate;
 
 G_DEFINE_TYPE_WITH_PRIVATE(GCVDrawingOptions, gcv_drawing_options, G_TYPE_OBJECT)
@@ -37,13 +37,13 @@ G_DEFINE_TYPE_WITH_PRIVATE(GCVDrawingOptions, gcv_drawing_options, G_TYPE_OBJECT
                                GCVDrawingOptionsPrivate))
 
 enum {
-  PROP_THICKNESS = 1,
-  PROP_LINE_TYPE,
-  PROP_SHIFT,
-  PROP_TIP_LENGTH,
-  PROP_BOTTOM_LEFT_ORIGIN,
+  PROP_LINE_TYPE = 1,
+  PROP_MARKER_SIZE,
   PROP_MARKER_TYPE,
-  PROP_MARKER_SIZE
+  PROP_SHIFT,
+  PROP_THICKNESS,
+  PROP_TIP_LENGTH,
+  PROP_USE_BOTTOM_LEFT_ORIGIN
 };
 
 static void
@@ -55,26 +55,26 @@ gcv_drawing_options_get_property(GObject *object,
   auto priv = GCV_DRAWING_OPTIONS_GET_PRIVATE(object);
 
   switch (prop_id) {
-  case PROP_THICKNESS:
-    g_value_set_int(value, priv->thickness);
-    break;
   case PROP_LINE_TYPE:
     g_value_set_enum(value, priv->line_type);
     break;
-  case PROP_SHIFT:
-    g_value_set_int(value, priv->shift);
-    break;
-  case PROP_TIP_LENGTH:
-    g_value_set_double(value, priv->tip_length);
-    break;
-  case PROP_BOTTOM_LEFT_ORIGIN:
-    g_value_set_boolean(value, priv->bottom_left_origin);
+  case PROP_MARKER_SIZE:
+    g_value_set_int(value, priv->marker_size);
     break;
   case PROP_MARKER_TYPE:
     g_value_set_enum(value, priv->marker_type);
     break;
-  case PROP_MARKER_SIZE:
-    g_value_set_int(value, priv->marker_size);
+  case PROP_SHIFT:
+    g_value_set_int(value, priv->shift);
+    break;
+  case PROP_THICKNESS:
+    g_value_set_int(value, priv->thickness);
+    break;
+  case PROP_TIP_LENGTH:
+    g_value_set_double(value, priv->tip_length);
+    break;
+  case PROP_USE_BOTTOM_LEFT_ORIGIN:
+    g_value_set_boolean(value, priv->use_bottom_left_origin);
     break;
   default:
     G_OBJECT_WARN_INVALID_PROPERTY_ID(object, prop_id, pspec);
@@ -91,26 +91,26 @@ gcv_drawing_options_set_property(GObject *object,
   auto priv = GCV_DRAWING_OPTIONS_GET_PRIVATE(object);
 
   switch (prop_id) {
-  case PROP_THICKNESS:
-    priv->thickness = g_value_get_int(value);
-    break;
   case PROP_LINE_TYPE:
     priv->line_type = static_cast<GCVLineType>(g_value_get_enum(value));
     break;
-  case PROP_SHIFT:
-    priv->shift = g_value_get_int(value);
-    break;
-  case PROP_TIP_LENGTH:
-    priv->tip_length = g_value_get_double(value);
-    break;
-  case PROP_BOTTOM_LEFT_ORIGIN:
-    priv->bottom_left_origin = g_value_get_boolean(value);
+  case PROP_MARKER_SIZE:
+    priv->marker_size = g_value_get_int(value);
     break;
   case PROP_MARKER_TYPE:
     priv->marker_type = static_cast<GCVMarkerType>(g_value_get_enum(value));
     break;
-  case PROP_MARKER_SIZE:
-    priv->marker_size = g_value_get_int(value);
+  case PROP_SHIFT:
+    priv->shift = g_value_get_int(value);
+    break;
+  case PROP_THICKNESS:
+    priv->thickness = g_value_get_int(value);
+    break;
+  case PROP_TIP_LENGTH:
+    priv->tip_length = g_value_get_double(value);
+    break;
+  case PROP_USE_BOTTOM_LEFT_ORIGIN:
+    priv->use_bottom_left_origin = g_value_get_boolean(value);
     break;
   default:
     G_OBJECT_WARN_INVALID_PROPERTY_ID(object, prop_id, pspec);
@@ -133,13 +133,6 @@ gcv_drawing_options_class_init(GCVDrawingOptionsClass *klass)
   gobject_class->get_property = gcv_drawing_options_get_property;
   gobject_class->set_property = gcv_drawing_options_set_property;
 
-  spec = g_param_spec_int("thickness",
-                          "Thickness",
-                          "The thickness of line to be drawn",
-                          0, G_MAXINT, 1,
-                          static_cast<GParamFlags>(G_PARAM_READWRITE |
-                                                   G_PARAM_CONSTRUCT));
-  g_object_class_install_property(gobject_class, PROP_THICKNESS, spec);
   spec = g_param_spec_enum("line-type",
                            "Line type",
                            "The type of line to be drawn",
@@ -148,27 +141,13 @@ gcv_drawing_options_class_init(GCVDrawingOptionsClass *klass)
                            static_cast<GParamFlags>(G_PARAM_READWRITE |
                                                     G_PARAM_CONSTRUCT));
   g_object_class_install_property(gobject_class, PROP_LINE_TYPE, spec);
-  spec = g_param_spec_int("shift",
-                          "Shift",
-                          "The number of fractional bits in the point coordinates",
-                          0, G_MAXINT, 0,
+  spec = g_param_spec_int("marker-size",
+                          "Marker size",
+                          "The length of the marker axis",
+                          0, G_MAXINT, 20,
                           static_cast<GParamFlags>(G_PARAM_READWRITE |
                                                    G_PARAM_CONSTRUCT));
-  g_object_class_install_property(gobject_class, PROP_SHIFT, spec);
-  spec = g_param_spec_double("tip-length",
-                             "Tip length",
-                             "The length of the arrow tip in relation to the arrow length",
-                             0, G_MAXDOUBLE, 0.1,
-                             static_cast<GParamFlags>(G_PARAM_READWRITE |
-                                                      G_PARAM_CONSTRUCT));
-  g_object_class_install_property(gobject_class, PROP_TIP_LENGTH, spec);
-  spec = g_param_spec_boolean("bottom-left-origin",
-                              "Bottom left origin",
-                              "When true, the image data origin is at the bottom-left corner. Otherwise, it is at the top-left corner.",
-                              FALSE,
-                              static_cast<GParamFlags>(G_PARAM_READWRITE |
-                                                       G_PARAM_CONSTRUCT));
-  g_object_class_install_property(gobject_class, PROP_BOTTOM_LEFT_ORIGIN, spec);
+  g_object_class_install_property(gobject_class, PROP_MARKER_SIZE, spec);
   spec = g_param_spec_enum("marker-type",
                            "Marker type",
                            "The type of marker to be drawn",
@@ -177,13 +156,34 @@ gcv_drawing_options_class_init(GCVDrawingOptionsClass *klass)
                            static_cast<GParamFlags>(G_PARAM_READWRITE |
                                                     G_PARAM_CONSTRUCT));
   g_object_class_install_property(gobject_class, PROP_MARKER_TYPE, spec);
-  spec = g_param_spec_int("marker-size",
-                          "Marker size",
-                          "The length of the marker axis",
-                          0, G_MAXINT, 20,
+  spec = g_param_spec_int("shift",
+                          "Shift",
+                          "The number of fractional bits in the point coordinates",
+                          0, G_MAXINT, 0,
                           static_cast<GParamFlags>(G_PARAM_READWRITE |
                                                    G_PARAM_CONSTRUCT));
-  g_object_class_install_property(gobject_class, PROP_MARKER_SIZE, spec);
+  g_object_class_install_property(gobject_class, PROP_SHIFT, spec);
+  spec = g_param_spec_int("thickness",
+                          "Thickness",
+                          "The thickness of line to be drawn",
+                          0, G_MAXINT, 1,
+                          static_cast<GParamFlags>(G_PARAM_READWRITE |
+                                                   G_PARAM_CONSTRUCT));
+  g_object_class_install_property(gobject_class, PROP_THICKNESS, spec);
+  spec = g_param_spec_double("tip-length",
+                             "Tip length",
+                             "The length of the arrow tip in relation to the arrow length",
+                             0, G_MAXDOUBLE, 0.1,
+                             static_cast<GParamFlags>(G_PARAM_READWRITE |
+                                                      G_PARAM_CONSTRUCT));
+  g_object_class_install_property(gobject_class, PROP_TIP_LENGTH, spec);
+  spec = g_param_spec_boolean("use-bottom-left-origin",
+                              "Use bottom left origin",
+                              "When true, the image data origin is at the bottom-left corner. Otherwise, it is at the top-left corner.",
+                              FALSE,
+                              static_cast<GParamFlags>(G_PARAM_READWRITE |
+                                                       G_PARAM_CONSTRUCT));
+  g_object_class_install_property(gobject_class, PROP_USE_BOTTOM_LEFT_ORIGIN, spec);
 }
 
 /**
@@ -496,7 +496,7 @@ gcv_image_put_text(GCVImage *image,
                 *cv_color,
                 options_priv->thickness,
                 options_priv->line_type,
-                options_priv->bottom_left_origin);
+                options_priv->use_bottom_left_origin);
   } else {
     cv::putText(*cv_image,
                 text,

--- a/opencv-glib/image.h
+++ b/opencv-glib/image.h
@@ -116,6 +116,11 @@ gboolean gcv_image_write(GCVImage *image,
 
 GCVImage *gcv_image_convert_color(GCVImage *image,
                                   GCVColorConversionCode code);
+void gcv_image_draw_arrowed_line(GCVImage *image,
+                                 GCVPoint *point1,
+                                 GCVPoint *point2,
+                                 GCVColor *color,
+                                 GCVDrawingOptions *drawing_options);
 void gcv_image_draw_circle(GCVImage *image,
                            GCVPoint *center,
                            gint radius,

--- a/opencv-glib/image.h
+++ b/opencv-glib/image.h
@@ -8,6 +8,40 @@
 G_BEGIN_DECLS
 
 /**
+ * GCVHersheyFont:
+ * @GCV_HERSHEY_FONT_HERSHEY_SIMPLEX: See `cv::HersheyFonts::FONT_HERSHEY_SIMPLEX`.
+ * @GCV_HERSHEY_FONT_HERSHEY_PLAIN: See `cv::HersheyFonts::FONT_HERSHEY_PLAIN`.
+ * @GCV_HERSHEY_FONT_HERSHEY_DUPLEX: See `cv::HersheyFonts::FONT_HERSHEY_DUPLEX`.
+ * @GCV_HERSHEY_FONT_HERSHEY_COMPLEX: See `cv::HersheyFonts::FONT_HERSHEY_COMPLEX`.
+ * @GCV_HERSHEY_FONT_HERSHEY_TRIPLEX: See `cv::HersheyFonts::FONT_HERSHEY_TRIPLEX`.
+ * @GCV_HERSHEY_FONT_HERSHEY_COMPLEX_SMALL: See `cv::HersheyFonts::FONT_HERSHEY_COMPLEX_SMALL`.
+ * @GCV_HERSHEY_FONT_HERSHEY_SCRIPT_SIMPLEX: See `cv::HersheyFonts::FONT_HERSHEY_SCRIPT_SIMPLEX`.
+ * @GCV_HERSHEY_FONT_HERSHEY_SCRIPT_COMPLEX: See `cv::HersheyFonts::FONT_HERSHEY_SCRIPT_COMPLEX`.
+ * @GCV_HERSHEY_FONT_ITALIC: See `cv::HersheyFonts::FONT_ITALIC`.
+ *
+ * Line type for drawing functions corresponding to `cv::HersheyFonts`.
+ *
+ * See also [OpenCV documents](https://docs.opencv.org/).
+ *
+ * We don't have a link to the latest `cv::HersheyFonts` document.
+ * But we can link to a specific version:
+ * [OpenCV 3.4.1's `cv::HersheyFonts`](https://docs.opencv.org/3.4.1/d0/de1/group__core.html#ga0f9314ea6e35f99bb23f29567fc16e11).
+ *
+ * Since 1.0.2
+ */
+typedef enum {
+  GCV_HERSHEY_FONT_HERSHEY_SIMPLEX = 0,
+  GCV_HERSHEY_FONT_HERSHEY_PLAIN = 1,
+  GCV_HERSHEY_FONT_HERSHEY_DUPLEX = 2,
+  GCV_HERSHEY_FONT_HERSHEY_COMPLEX = 3,
+  GCV_HERSHEY_FONT_HERSHEY_TRIPLEX = 4,
+  GCV_HERSHEY_FONT_HERSHEY_COMPLEX_SMALL = 5,
+  GCV_HERSHEY_FONT_HERSHEY_SCRIPT_SIMPLEX = 6,
+  GCV_HERSHEY_FONT_HERSHEY_SCRIPT_COMPLEX = 7,
+  GCV_HERSHEY_FONT_ITALIC = 16
+} GCVHersheyFont;
+
+/**
  * GCVLineType:
  * @GCV_LINE_TYPE_FILLED: See `cv::LineTypes::FILLED`.
  * @GCV_LINE_TYPE_LINE_4: See `cv::LineTypes::LINE_4`.
@@ -131,6 +165,13 @@ void gcv_image_draw_line(GCVImage *image,
                          GCVPoint *point2,
                          GCVColor *color,
                          GCVDrawingOptions *drawing_options);
+void gcv_image_put_text(GCVImage *image,
+                        const gchar *text,
+                        GCVPoint *org,
+                        GCVHersheyFont font_face,
+                        gdouble font_scale,
+                        GCVColor *color,
+                        GCVDrawingOptions *drawing_options);
 void gcv_image_draw_rectangle(GCVImage *image,
                               GCVRectangle *rectangle,
                               GCVColor *color,

--- a/opencv-glib/image.h
+++ b/opencv-glib/image.h
@@ -65,6 +65,36 @@ typedef enum {
   GCV_LINE_TYPE_LINE_AA = 16
 } GCVLineType;
 
+/**
+ * GCVMarkerType:
+ * @GCV_MARKER_TYPE_CROSS: See `cv::MarkerTypes::MARKER_CROSS`.
+ * @GCV_MARKER_TYPE_TILTED_CROSS: See `cv::MarkerTypes::MARKER_TILTED_CROSS`.
+ * @GCV_MARKER_TYPE_STAR: See `cv::MarkerTypes::MARKER_STAR`.
+ * @GCV_MARKER_TYPE_DIAMOND: See `cv::MarkerTypes::MARKER_DIAMOND`.
+ * @GCV_MARKER_TYPE_SQUARE: See `cv::MarkerTypes::MARKER_SQUARE`.
+ * @GCV_MARKER_TYPE_TRIANGLE_UP: See `cv::MarkerTypes::MARKER_TRIANGLE_UP`.
+ * @GCV_MARKER_TYPE_TRIANGLE_DOWN: See `cv::MarkerTypes::MARKER_TRIANGLE_DOWN`.
+ *
+ * Line type for drawing functions corresponding to `cv::MarkerTypes`.
+ *
+ * See also [OpenCV documents](https://docs.opencv.org/).
+ *
+ * We don't have a link to the latest `cv::MarkerTypes` document.
+ * But we can link to a specific version:
+ * [OpenCV 3.4.1's `cv::MarkerTypes`](https://docs.opencv.org/3.4.1/d6/d6e/group__imgproc__draw.html#ga0ad87faebef1039ec957737ecc633b7b).
+ *
+ * Since 1.0.2
+ */
+typedef enum {
+  GCV_MARKER_TYPE_CROSS = 0,
+  GCV_MARKER_TYPE_TILTED_CROSS = 1,
+  GCV_MARKER_TYPE_STAR = 2,
+  GCV_MARKER_TYPE_DIAMOND = 3,
+  GCV_MARKER_TYPE_SQUARE = 4,
+  GCV_MARKER_TYPE_TRIANGLE_UP = 5,
+  GCV_MARKER_TYPE_TRIANGLE_DOWN = 6
+} GCVMarkerType;
+
 #define GCV_TYPE_DRAWING_OPTIONS (gcv_drawing_options_get_type())
 G_DECLARE_DERIVABLE_TYPE(GCVDrawingOptions,
                          gcv_drawing_options,
@@ -158,6 +188,10 @@ void gcv_image_draw_arrowed_line(GCVImage *image,
 void gcv_image_draw_circle(GCVImage *image,
                            GCVPoint *center,
                            gint radius,
+                           GCVColor *color,
+                           GCVDrawingOptions *drawing_options);
+void gcv_image_draw_marker(GCVImage *image,
+                           GCVPoint *position,
                            GCVColor *color,
                            GCVDrawingOptions *drawing_options);
 void gcv_image_draw_line(GCVImage *image,

--- a/test/test-image.rb
+++ b/test/test-image.rb
@@ -159,6 +159,41 @@ class TestImage < Test::Unit::TestCase
       end
     end
 
+    sub_test_case("#put_text") do
+      def test_simple
+        cloned_image = @image.clone
+        @image.put_text("hello",
+                        CV::Point.new(0, 30),
+                        :hershey_simplex, 2,
+                        CV::Color.new(255, 127, 0, 2))
+        assert_not_equal(cloned_image.bytes.to_s,
+                         @image.bytes.to_s)
+      end
+
+      def test_drawing_options
+        cloned_image = @image.clone
+        point = CV::Point.new(0, 16)
+        color = CV::Color.new(255, 127, 0, 2)
+        drawing_options = CV::DrawingOptions.new
+        drawing_options.thickness = 5
+        drawing_options.line_type = :line_aa
+        drawing_options.bottom_left_origin = true
+        cloned_image.put_text("Hello",
+                              point,
+                              :hershey_simplex,
+                              2,
+                              color) # draw without options
+        @image.put_text("Hello",
+                        point,
+                        :hershey_simplex,
+                        2,
+                        color,
+                        drawing_options) # draw with options
+        assert_not_equal(cloned_image.bytes.to_s,
+                         @image.bytes.to_s)
+      end
+    end
+
     sub_test_case("#rectangle") do
       def test_simple
         cloned_image = @image.clone

--- a/test/test-image.rb
+++ b/test/test-image.rb
@@ -204,7 +204,7 @@ class TestImage < Test::Unit::TestCase
         drawing_options = CV::DrawingOptions.new
         drawing_options.thickness = 5
         drawing_options.line_type = :line_aa
-        drawing_options.bottom_left_origin = true
+        drawing_options.use_bottom_left_origin = true
         cloned_image.put_text("Hello",
                               point,
                               :hershey_simplex,

--- a/test/test-image.rb
+++ b/test/test-image.rb
@@ -72,6 +72,36 @@ class TestImage < Test::Unit::TestCase
       end
     end
 
+    sub_test_case("#arrowed_line") do
+      def test_simple
+        cloned_image = @image.clone
+        @image.draw_arrowed_line(CV::Point.new(10, 0),
+                                 CV::Point.new(10, 30),
+                                 CV::Color.new(255, 127, 0, 2))
+        assert_not_equal(cloned_image.bytes.to_s,
+                         @image.bytes.to_s)
+      end
+
+      def test_drawing_options
+        cloned_image = @image.clone
+        point1 = CV::Point.new(10, 0)
+        point2 = CV::Point.new(10, 30)
+        color = CV::Color.new(255, 127, 0, 2)
+        drawing_options = CV::DrawingOptions.new
+        drawing_options.thickness = 5
+        drawing_options.line_type = :line_aa
+        drawing_options.shift = 2
+        drawing_options.tip_length = 1
+        cloned_image.draw_arrowed_line(point1, point2, color) # draw without options
+        @image.draw_arrowed_line(point1,
+                                 point2,
+                                 color,
+                                 drawing_options) # draw with options
+        assert_not_equal(cloned_image.bytes.to_s,
+                         @image.bytes.to_s)
+      end
+    end
+
     sub_test_case("#circle") do
       def test_simple
         cloned_image = @image.clone

--- a/test/test-image.rb
+++ b/test/test-image.rb
@@ -130,6 +130,33 @@ class TestImage < Test::Unit::TestCase
       end
     end
 
+    sub_test_case("#marker") do
+      def test_simple
+        cloned_image = @image.clone
+        @image.draw_marker(CV::Point.new(16, 16),
+                           CV::Color.new(255, 127, 0, 2))
+        assert_not_equal(cloned_image.bytes.to_s,
+                         @image.bytes.to_s)
+      end
+
+      def test_drawing_options
+        cloned_image = @image.clone
+        point = CV::Point.new(16, 16)
+        color = CV::Color.new(255, 127, 0, 2)
+        drawing_options = CV::DrawingOptions.new
+        drawing_options.marker_type = :triangle_up
+        drawing_options.marker_size = 30
+        drawing_options.thickness = 5
+        drawing_options.line_type = :line_aa
+        cloned_image.draw_marker(point, color) # draw without options
+        @image.draw_marker(point,
+                           color,
+                           drawing_options) # draw with options
+        assert_not_equal(cloned_image.bytes.to_s,
+                         @image.bytes.to_s)
+      end
+    end
+
     sub_test_case("#line") do
       def test_simple
         cloned_image = @image.clone


### PR DESCRIPTION
Add 3 drawing functions which require adding new members to `GCVDrawingOptions`.

* `gcv_image_draw_arrowed_line()`
  * `tip_length` is added to `GCVDrawingOptions`
* `gcv_image_put_text()`
  * `bottom_left_origin` is added to `GCVDrawingOptions`
  * `GCVHersheyFont` enum type is added
* `gcv_image_draw_marker()`
  * `marker_type` and `marker_size` are added to `GCVDrawingOptions`
  * `GCVMarkerType` enum type is added

### Questions

* In this pull request, 4 properties are added to `GCVDrawingOptions` class. Is thre any rule for the order of properties (e.g. sort with alphabetical order)? Now they are simply added to the bottom of the structure.
