### PR TITLE
Add draw ellipse

### DIFF
--- a/opencv-glib/image.cpp
+++ b/opencv-glib/image.cpp
@@ -4,6 +4,7 @@
 #include <opencv-glib/image-error.h>
 #include <opencv-glib/point.hpp>
 #include <opencv-glib/rectangle.hpp>
+#include <opencv-glib/size.hpp>
 
 #include <opencv2/imgproc.hpp>
 
@@ -417,6 +418,58 @@ gcv_image_draw_marker(GCVImage *image,
     cv::drawMarker(*cv_image,
                    *cv_position,
                    *cv_color);
+  }
+}
+
+/**
+ * gcv_image_draw_ellipse_point:
+ * @image: A #GCVImage.
+ * @center: A #GCVPoint to specify center.
+ * @axes: A #GCVSize to specify the half of the size of the ellipse main axes.
+ * @angle: The ellipse rotation angle in degrees.
+ * @start_angle: The starting angle of the elliptic arc in degrees.
+ * @end_angle: The ending angle of the elliptic arc in degrees.
+ * @color: A #GCVColor to specify line color.
+ * @drawing_options: (nullable): A #GCVDrawingOptions to specify optional parameters.
+ *
+ * It draws an ellipse on @center position with @axes, @angle, @start_angle, @end_angle, @color and @drawing_options
+ *
+ * Since: 1.0.3
+ */
+void
+gcv_image_draw_ellipse_point(GCVImage *image,
+                             GCVPoint *center,
+                             GCVSize *axes,
+                             gdouble angle,
+                             gdouble start_angle,
+                             gdouble end_angle,
+                             GCVColor *color,
+                             GCVDrawingOptions *drawing_options)
+{
+  auto cv_image = gcv_matrix_get_raw(GCV_MATRIX(image));
+  auto cv_center = gcv_point_get_raw(center);
+  auto cv_axes = gcv_size_get_raw(axes);
+  auto cv_color = gcv_color_get_raw(color);
+  if (drawing_options) {
+    auto options_priv = GCV_DRAWING_OPTIONS_GET_PRIVATE(drawing_options);
+    cv::ellipse(*cv_image,
+                *cv_center,
+                *cv_axes,
+                angle,
+                start_angle,
+                end_angle,
+                *cv_color,
+                options_priv->thickness,
+                options_priv->line_type,
+                options_priv->shift);
+  } else {
+    cv::ellipse(*cv_image,
+                *cv_center,
+                *cv_axes,
+                angle,
+                start_angle,
+                end_angle,
+                *cv_color);
   }
 }
 

--- a/opencv-glib/image.h
+++ b/opencv-glib/image.h
@@ -4,6 +4,7 @@
 #include <opencv-glib/matrix.h>
 #include <opencv-glib/point.h>
 #include <opencv-glib/rectangle.h>
+#include <opencv-glib/size.h>
 
 G_BEGIN_DECLS
 
@@ -194,6 +195,14 @@ void gcv_image_draw_marker(GCVImage *image,
                            GCVPoint *position,
                            GCVColor *color,
                            GCVDrawingOptions *drawing_options);
+void gcv_image_draw_ellipse_point(GCVImage *image,
+                                  GCVPoint *center,
+                                  GCVSize *axes,
+                                  gdouble angle,
+                                  gdouble start_angle,
+                                  gdouble end_angle,
+                                  GCVColor *color,
+                                  GCVDrawingOptions *drawing_options);
 void gcv_image_draw_line(GCVImage *image,
                          GCVPoint *point1,
                          GCVPoint *point2,

--- a/opencv-glib/meson.build
+++ b/opencv-glib/meson.build
@@ -9,6 +9,7 @@ sources = files(
   'matrix.cpp',
   'point.cpp',
   'rectangle.cpp',
+  'size.cpp',
   'video-capture.cpp',
 )
 
@@ -24,6 +25,7 @@ c_headers = files(
   'opencv-glib.h',
   'point.h',
   'rectangle.h',
+  'size.h',
   'video-capture.h',
 )
 
@@ -36,6 +38,7 @@ cpp_headers = files(
   'opencv-glib.hpp',
   'point.hpp',
   'rectangle.hpp',
+  'size.hpp',
   'video-capture.hpp',
 )
 

--- a/opencv-glib/size.cpp
+++ b/opencv-glib/size.cpp
@@ -1,0 +1,186 @@
+#include <opencv-glib/size.hpp>
+
+G_BEGIN_DECLS
+
+/**
+ * SECTION: size
+ * @title: Size class
+ * @include: opencv-glib/opencv-glib.h
+ *
+ * #GCVSize is a size class.
+ *
+ * Since: 1.0.3
+ */
+
+typedef struct {
+  std::shared_ptr<cv::Size> size;
+} GCVSizePrivate;
+
+G_DEFINE_TYPE_WITH_PRIVATE(GCVSize, gcv_size, G_TYPE_OBJECT)
+
+#define GCV_SIZE_GET_PRIVATE(object)           \
+  static_cast<GCVSizePrivate *>(               \
+    gcv_size_get_instance_private(             \
+      GCV_SIZE(object)))
+
+enum {
+  PROP_SIZE = 1
+};
+
+static void
+gcv_size_finalize(GObject *object)
+{
+  auto priv = GCV_SIZE_GET_PRIVATE(object);
+
+  priv->size = nullptr;
+
+  G_OBJECT_CLASS(gcv_size_parent_class)->finalize(object);
+}
+
+static void
+gcv_size_set_property(GObject *object,
+                      guint prop_id,
+                      const GValue *value,
+                      GParamSpec *pspec)
+{
+  auto priv = GCV_SIZE_GET_PRIVATE(object);
+
+  switch (prop_id) {
+  case PROP_SIZE:
+    priv->size =
+      *static_cast<std::shared_ptr<cv::Size> *>(g_value_get_pointer(value));
+    break;
+  default:
+    G_OBJECT_WARN_INVALID_PROPERTY_ID(object, prop_id, pspec);
+    break;
+  }
+}
+
+static void
+gcv_size_init(GCVSize *object)
+{
+}
+
+static void
+gcv_size_class_init(GCVSizeClass *klass)
+{
+  GParamSpec *spec;
+
+  auto gobject_class = G_OBJECT_CLASS(klass);
+
+  gobject_class->finalize     = gcv_size_finalize;
+  gobject_class->set_property = gcv_size_set_property;
+
+  spec = g_param_spec_pointer("size",
+                              "Size",
+                              "The raw std::shared<cv::Size> *",
+                              static_cast<GParamFlags>(G_PARAM_WRITABLE |
+                                                       G_PARAM_CONSTRUCT_ONLY));
+  g_object_class_install_property(gobject_class, PROP_SIZE, spec);
+}
+
+/**
+ * gcv_size_new:
+ * @width: A width value of the size
+ * @height: A height value value of the size
+ *
+ * Returns: A newly created #GCVSize.
+ *
+ * Since: 1.0.3
+ */
+GCVSize *
+gcv_size_new(gint width, gint height)
+{
+  auto cv_size = std::make_shared<cv::Size>(width, height);
+  return gcv_size_new_raw(&cv_size);
+}
+
+/**
+ * gcv_size_new_empty:
+ *
+ * Returns: A newly created empty #GCVSize.
+ *
+ * Since: 1.0.3
+ */
+GCVSize *
+gcv_size_new_empty(void)
+{
+  auto cv_size = std::make_shared<cv::Size>();
+  return gcv_size_new_raw(&cv_size);
+}
+
+/**
+ * gcv_size_get_width:
+ * @size: A #GCVSize
+ *
+ * Returns: The width value of the size.
+ *
+ * Since: 1.0.3
+ */
+gint
+gcv_size_get_width(GCVSize *size)
+{
+  auto cv_size = gcv_size_get_raw(size);
+  return cv_size->width;
+}
+
+/**
+ * gcv_size_set_width:
+ * @size: A #GCVSize
+ * @width: A new width value of the size.
+ *
+ * Since: 1.0.3
+ */
+void
+gcv_size_set_width(GCVSize *size, gint width)
+{
+  auto cv_size = gcv_size_get_raw(size);
+  cv_size->width = width;
+}
+
+/**
+ * gcv_size_get_height:
+ * @size: A #GCVSize
+ *
+ * Returns: The height value of the size.
+ *
+ * Since: 1.0.3
+ */
+gint
+gcv_size_get_height(GCVSize *size)
+{
+  auto cv_size = gcv_size_get_raw(size);
+  return cv_size->height;
+}
+
+/**
+ * gcv_size_set_height:
+ * @size: A #GCVSize
+ * @height: A new height value of the size.
+ *
+ * Since: 1.0.3
+ */
+void
+gcv_size_set_height(GCVSize *size, gint height)
+{
+  auto cv_size = gcv_size_get_raw(size);
+  cv_size->height = height;
+}
+
+G_END_DECLS
+
+GCVSize *
+gcv_size_new_raw(std::shared_ptr<cv::Size> *cv_size)
+{
+  auto size = g_object_new(GCV_TYPE_SIZE,
+                            "size", cv_size,
+                            NULL);
+  return GCV_SIZE(size);
+}
+
+std::shared_ptr<cv::Size>
+gcv_size_get_raw(GCVSize *size)
+{
+  auto priv = GCV_SIZE_GET_PRIVATE(size);
+  return priv->size;
+}

--- a/opencv-glib/size.cpp
+++ b/opencv-glib/size.cpp
@@ -173,8 +173,8 @@ GCVSize *
 gcv_size_new_raw(std::shared_ptr<cv::Size> *cv_size)
 {
   auto size = g_object_new(GCV_TYPE_SIZE,
-                            "size", cv_size,
-                            NULL);
+                           "size", cv_size,
+                           NULL);
   return GCV_SIZE(size);
 }
 

--- a/opencv-glib/size.h
+++ b/opencv-glib/size.h
@@ -1,0 +1,26 @@
+#pragma once
+
+#include <glib-object.h>
+
+G_BEGIN_DECLS
+
+#define GCV_TYPE_SIZE (gcv_size_get_type())
+G_DECLARE_DERIVABLE_TYPE(GCVSize,
+                         gcv_size,
+                         GCV,
+                         SIZE,
+                         GObject)
+struct _GCVSizeClass
+{
+  GObjectClass parent_class;
+};
+
+GCVSize *gcv_size_new(gint width, gint height);
+GCVSize *gcv_size_new_empty(void);
+
+gint gcv_size_get_width(GCVSize *size);
+void gcv_size_set_width(GCVSize *size, gint width);
+gint gcv_size_get_height(GCVSize *size);
+void gcv_size_set_height(GCVSize *size, gint height);
+
+G_END_DECLS

--- a/opencv-glib/size.hpp
+++ b/opencv-glib/size.hpp
@@ -1,0 +1,10 @@
+#pragma once
+
+#include <memory>
+
+#include <opencv2/core/types.hpp>
+
+#include <opencv-glib/size.h>
+
+GCVSize *gcv_size_new_raw(std::shared_ptr<cv::Size> *cv_size);
+std::shared_ptr<cv::Size> gcv_size_get_raw(GCVSize *size);

--- a/test/test-image.rb
+++ b/test/test-image.rb
@@ -157,6 +157,37 @@ class TestImage < Test::Unit::TestCase
       end
     end
 
+    sub_test_case("#ellipse with point") do
+      def test_simple
+        cloned_image = @image.clone
+        @image.draw_ellipse_point(CV::Point.new(16, 16),
+                                  CV::Size.new(10, 8),
+                                  45,
+                                  0,
+                                  300,
+                                  CV::Color.new(255, 127, 0, 2))
+        assert_not_equal(cloned_image.bytes.to_s,
+                         @image.bytes.to_s)
+      end
+
+      def test_drawing_options
+        cloned_image = @image.clone
+        drawing_options = CV::DrawingOptions.new
+        drawing_options.thickness = 2
+        drawing_options.line_type = :line_aa
+        drawing_options.shift = 2
+        @image.draw_ellipse_point(CV::Point.new(16, 16),
+                                  CV::Size.new(10, 8),
+                                  45,
+                                  0,
+                                  300,
+                                  CV::Color.new(255, 127, 0, 2),
+                                  drawing_options)
+        assert_not_equal(cloned_image.bytes.to_s,
+                         @image.bytes.to_s)
+      end
+    end
+
     sub_test_case("#line") do
       def test_simple
         cloned_image = @image.clone

--- a/test/test-size.rb
+++ b/test/test-size.rb
@@ -1,0 +1,21 @@
+class TestSize < Test::Unit::TestCase
+  sub_test_case(".new") do
+    def test_empty
+      size = CV::Size.new
+      assert_equal([0, 0],
+                   [
+                     size.width,
+                     size.height,
+                   ])
+    end
+
+    def test_width_and_height
+      size = CV::Size.new(10, 20)
+      assert_equal([10, 20],
+                   [
+                     size.width,
+                     size.height,
+                   ])
+    end
+  end
+end


### PR DESCRIPTION
Add `GCVSize` class and `gcv_draw_ellipse_point()` method.

In C++ API, there are 2 `cv::ellipse` methods.
* `void cv::ellipse (InputOutputArray img, Point center, Size axes, double angle, double startAngle, double endAngle, const Scalar &color, int thickness=1, int lineType=LINE_8, int shift=0)`
* `void cv::ellipse (InputOutputArray img, const RotatedRect &box, const Scalar &color, int thickness=1, int lineType=LINE_8)`

This commit implements only the 1st one. The 2nd one is difficult to implement because `RoratedRect` class is hard to implement in GLib interface.