### PR TITLE
Add functions corresponding to cv::clipLine()

### DIFF
--- a/opencv-glib/rectangle.cpp
+++ b/opencv-glib/rectangle.cpp
@@ -250,8 +250,7 @@ gcv_rectangle_clip_line(GCVRectangle *rectangle,
   auto cv_rectangle = gcv_rectangle_get_raw(rectangle);
   auto cv_point1 = gcv_point_get_raw(*point1);
   auto cv_point2 = gcv_point_get_raw(*point2);
-  gboolean ret = cv::clipLine(*cv_rectangle, *cv_point1, *cv_point2);
-  return ret;
+  return cv::clipLine(*cv_rectangle, *cv_point1, *cv_point2);
 }
 
 G_END_DECLS

--- a/opencv-glib/rectangle.cpp
+++ b/opencv-glib/rectangle.cpp
@@ -242,7 +242,9 @@ gcv_rectangle_set_height(GCVRectangle *rectangle, gint height)
  * Since: 1.0.3
  */
 gboolean
-gcv_rectangle_clip_line(GCVRectangle* rectangle, GCVPoint **point1, GCVPoint **point2)
+gcv_rectangle_clip_line(GCVRectangle *rectangle,
+                        GCVPoint **point1,
+                        GCVPoint **point2)
 {
   auto cv_rectangle = gcv_rectangle_get_raw(rectangle);
   auto cv_point1 = gcv_point_get_raw(*point1);

--- a/opencv-glib/rectangle.cpp
+++ b/opencv-glib/rectangle.cpp
@@ -237,7 +237,8 @@ gcv_rectangle_set_height(GCVRectangle *rectangle, gint height)
  * @point1: (inout): A #GCVPoint to specify the first point
  * @point2: (inout): A #GCVPoint to specify the second point
  *
- * Returns: %FALSE if the line segment is completely outside the rectangle. Otherwise %TRUE.
+ * Returns: %FALSE if the line segment is completely outside the
+ *   rectangle, %TRUE otherwise.
  *
  * Since: 1.0.3
  */

--- a/opencv-glib/rectangle.cpp
+++ b/opencv-glib/rectangle.cpp
@@ -1,5 +1,5 @@
-#include <opencv-glib/rectangle.hpp>
 #include <opencv-glib/point.hpp>
+#include <opencv-glib/rectangle.hpp>
 
 #include <opencv2/imgproc.hpp>
 

--- a/opencv-glib/rectangle.cpp
+++ b/opencv-glib/rectangle.cpp
@@ -1,4 +1,7 @@
 #include <opencv-glib/rectangle.hpp>
+#include <opencv-glib/point.hpp>
+
+#include <opencv2/imgproc.hpp>
 
 G_BEGIN_DECLS
 
@@ -226,6 +229,26 @@ gcv_rectangle_set_height(GCVRectangle *rectangle, gint height)
 {
   auto cv_rectangle = gcv_rectangle_get_raw(rectangle);
   cv_rectangle->height = height;
+}
+
+/**
+ * gcv_rectangle_clip_line:
+ * @rectangle: A #GCVRectangle
+ * @point1: (inout): A #GCVPoint to specify the first point
+ * @point2: (inout): A #GCVPoint to specify the second point
+ *
+ * Returns: %FALSE if the line segment is completely outside the rectangle. Otherwise %TRUE.
+ *
+ * Since: 1.0.3
+ */
+gboolean
+gcv_rectangle_clip_line(GCVRectangle* rectangle, GCVPoint **point1, GCVPoint **point2)
+{
+  auto cv_rectangle = gcv_rectangle_get_raw(rectangle);
+  auto cv_point1 = gcv_point_get_raw(*point1);
+  auto cv_point2 = gcv_point_get_raw(*point2);
+  gboolean ret = cv::clipLine(*cv_rectangle, *cv_point1, *cv_point2);
+  return ret;
 }
 
 G_END_DECLS

--- a/opencv-glib/rectangle.h
+++ b/opencv-glib/rectangle.h
@@ -26,6 +26,8 @@ gint gcv_rectangle_get_width(GCVRectangle *rectangle);
 void gcv_rectangle_set_width(GCVRectangle *rectangle, gint width);
 gint gcv_rectangle_get_height(GCVRectangle *rectangle);
 void gcv_rectangle_set_height(GCVRectangle *rectangle, gint height);
-gboolean gcv_rectangle_clip_line(GCVRectangle* rectangle, GCVPoint **point1, GCVPoint **point2);
+gboolean gcv_rectangle_clip_line(GCVRectangle *rectangle,
+                                 GCVPoint **point1,
+                                 GCVPoint **point2);
 
 G_END_DECLS

--- a/opencv-glib/rectangle.h
+++ b/opencv-glib/rectangle.h
@@ -1,6 +1,5 @@
 #pragma once
 
-#include <glib-object.h>
 #include <opencv-glib/point.h>
 
 G_BEGIN_DECLS

--- a/opencv-glib/rectangle.h
+++ b/opencv-glib/rectangle.h
@@ -1,6 +1,7 @@
 #pragma once
 
 #include <glib-object.h>
+#include <opencv-glib/point.h>
 
 G_BEGIN_DECLS
 
@@ -26,5 +27,6 @@ gint gcv_rectangle_get_width(GCVRectangle *rectangle);
 void gcv_rectangle_set_width(GCVRectangle *rectangle, gint width);
 gint gcv_rectangle_get_height(GCVRectangle *rectangle);
 void gcv_rectangle_set_height(GCVRectangle *rectangle, gint height);
+gboolean gcv_rectangle_clip_line(GCVRectangle* rectangle, GCVPoint **point1, GCVPoint **point2);
 
 G_END_DECLS

--- a/opencv-glib/size.cpp
+++ b/opencv-glib/size.cpp
@@ -176,7 +176,8 @@ gcv_size_set_height(GCVSize *size, gint height)
  * @point1: (inout): A #GCVPoint to specify the first point
  * @point2: (inout): A #GCVPoint to specify the second point
  *
- * Returns: %FALSE if the line segment is completely outside the rectangle. Otherwise %TRUE.
+ * Returns: %FALSE if the line segment is completely outside the
+ *   rectangle, %TRUE otherwise.
  *
  * Since: 1.0.3
  */

--- a/opencv-glib/size.cpp
+++ b/opencv-glib/size.cpp
@@ -187,8 +187,7 @@ gcv_size_clip_line(GCVSize *size, GCVPoint **point1, GCVPoint **point2)
   auto cv_size = gcv_size_get_raw(size);
   auto cv_point1 = gcv_point_get_raw(*point1);
   auto cv_point2 = gcv_point_get_raw(*point2);
-  gboolean ret = cv::clipLine(*cv_size, *cv_point1, *cv_point2);
-  return ret;
+  return cv::clipLine(*cv_size, *cv_point1, *cv_point2);
 }
 
 G_END_DECLS

--- a/opencv-glib/size.cpp
+++ b/opencv-glib/size.cpp
@@ -1,5 +1,5 @@
-#include <opencv-glib/size.hpp>
 #include <opencv-glib/point.hpp>
+#include <opencv-glib/size.hpp>
 
 #include <opencv2/imgproc.hpp>
 

--- a/opencv-glib/size.cpp
+++ b/opencv-glib/size.cpp
@@ -1,4 +1,7 @@
 #include <opencv-glib/size.hpp>
+#include <opencv-glib/point.hpp>
+
+#include <opencv2/imgproc.hpp>
 
 G_BEGIN_DECLS
 
@@ -165,6 +168,26 @@ gcv_size_set_height(GCVSize *size, gint height)
 {
   auto cv_size = gcv_size_get_raw(size);
   cv_size->height = height;
+}
+
+/**
+ * gcv_size_clip_line:
+ * @size: A #GCVSize
+ * @point1: (inout): A #GCVPoint to specify the first point
+ * @point2: (inout): A #GCVPoint to specify the second point
+ *
+ * Returns: %FALSE if the line segment is completely outside the rectangle. Otherwise %TRUE.
+ *
+ * Since: 1.0.3
+ */
+gboolean
+gcv_size_clip_line(GCVSize *size, GCVPoint **point1, GCVPoint **point2)
+{
+  auto cv_size = gcv_size_get_raw(size);
+  auto cv_point1 = gcv_point_get_raw(*point1);
+  auto cv_point2 = gcv_point_get_raw(*point2);
+  gboolean ret = cv::clipLine(*cv_size, *cv_point1, *cv_point2);
+  return ret;
 }
 
 G_END_DECLS

--- a/opencv-glib/size.h
+++ b/opencv-glib/size.h
@@ -1,6 +1,5 @@
 #pragma once
 
-#include <glib-object.h>
 #include <opencv-glib/point.h>
 
 G_BEGIN_DECLS

--- a/opencv-glib/size.h
+++ b/opencv-glib/size.h
@@ -1,6 +1,7 @@
 #pragma once
 
 #include <glib-object.h>
+#include <opencv-glib/point.h>
 
 G_BEGIN_DECLS
 
@@ -22,5 +23,6 @@ gint gcv_size_get_width(GCVSize *size);
 void gcv_size_set_width(GCVSize *size, gint width);
 gint gcv_size_get_height(GCVSize *size);
 void gcv_size_set_height(GCVSize *size, gint height);
+gboolean gcv_size_clip_line(GCVSize *size, GCVPoint **point1, GCVPoint **point2);
 
 G_END_DECLS

--- a/test/test-rectangle.rb
+++ b/test/test-rectangle.rb
@@ -28,10 +28,10 @@ class TestRectangle < Test::Unit::TestCase
       rectangle = CV::Rectangle.new(10, 10, 80, 80)
       pt1 = CV::Point.new(0, 10)
       pt2 = CV::Point.new(100, 90)
-      ret, new_pt1, new_pt2 = rectangle.clip_line(pt1, pt2)
+      inside, new_pt1, new_pt2 = rectangle.clip_line(pt1, pt2)
       assert_equal([true, 10, 17, 89, 81],
                    [
-                     ret,
+                     inside,
                      new_pt1.x,
                      new_pt1.y,
                      new_pt2.x,
@@ -43,10 +43,10 @@ class TestRectangle < Test::Unit::TestCase
       rectangle = CV::Rectangle.new(10, 10, 80, 80)
       pt1 = CV::Point.new(200, 200)
       pt2 = CV::Point.new(300, 300)
-      ret, new_pt1, new_pt2 = rectangle.clip_line(pt1, pt2)
+      inside, new_pt1, new_pt2 = rectangle.clip_line(pt1, pt2)
       assert_equal([false, 200, 200, 300, 300],
                    [
-                     ret,
+                     inside,
                      new_pt1.x,
                      new_pt1.y,
                      new_pt2.x,

--- a/test/test-rectangle.rb
+++ b/test/test-rectangle.rb
@@ -26,31 +26,31 @@ class TestRectangle < Test::Unit::TestCase
   sub_test_case("#clip_line") do
     def test_true
       rectangle = CV::Rectangle.new(10, 10, 80, 80)
-      pt1 = CV::Point.new(0, 10)
-      pt2 = CV::Point.new(100, 90)
-      inside, new_pt1, new_pt2 = rectangle.clip_line(pt1, pt2)
+      point1 = CV::Point.new(0, 10)
+      point2 = CV::Point.new(100, 90)
+      inside, new_point1, new_point2 = rectangle.clip_line(point1, point2)
       assert_equal([true, 10, 17, 89, 81],
                    [
                      inside,
-                     new_pt1.x,
-                     new_pt1.y,
-                     new_pt2.x,
-                     new_pt2.y
+                     new_point1.x,
+                     new_point1.y,
+                     new_point2.x,
+                     new_point2.y
                    ])
     end
 
     def test_false
       rectangle = CV::Rectangle.new(10, 10, 80, 80)
-      pt1 = CV::Point.new(200, 200)
-      pt2 = CV::Point.new(300, 300)
-      inside, new_pt1, new_pt2 = rectangle.clip_line(pt1, pt2)
+      point1 = CV::Point.new(200, 200)
+      point2 = CV::Point.new(300, 300)
+      inside, new_point1, new_point2 = rectangle.clip_line(point1, point2)
       assert_equal([false, 200, 200, 300, 300],
                    [
                      inside,
-                     new_pt1.x,
-                     new_pt1.y,
-                     new_pt2.x,
-                     new_pt2.y
+                     new_point1.x,
+                     new_point1.y,
+                     new_point2.x,
+                     new_point2.y
                    ])
     end
   end

--- a/test/test-rectangle.rb
+++ b/test/test-rectangle.rb
@@ -22,4 +22,36 @@ class TestRectangle < Test::Unit::TestCase
                    ])
     end
   end
+
+  sub_test_case("#clip_line") do
+    def test_true
+      rectangle = CV::Rectangle.new(10, 10, 80, 80)
+      pt1 = CV::Point.new(0, 10)
+      pt2 = CV::Point.new(100, 90)
+      ret, new_pt1, new_pt2 = rectangle.clip_line(pt1, pt2)
+      assert_equal([true, 10, 17, 89, 81],
+                   [
+                     ret,
+                     new_pt1.x,
+                     new_pt1.y,
+                     new_pt2.x,
+                     new_pt2.y
+                   ])
+    end
+
+    def test_false
+      rectangle = CV::Rectangle.new(10, 10, 80, 80)
+      pt1 = CV::Point.new(200, 200)
+      pt2 = CV::Point.new(300, 300)
+      ret, new_pt1, new_pt2 = rectangle.clip_line(pt1, pt2)
+      assert_equal([false, 200, 200, 300, 300],
+                   [
+                     ret,
+                     new_pt1.x,
+                     new_pt1.y,
+                     new_pt2.x,
+                     new_pt2.y
+                   ])
+    end
+  end
 end

--- a/test/test-size.rb
+++ b/test/test-size.rb
@@ -24,10 +24,10 @@ class TestSize < Test::Unit::TestCase
       size = CV::Size.new(100, 100)
       pt1 = CV::Point.new(-10, 0)
       pt2 = CV::Point.new(110, 100)
-      ret, new_pt1, new_pt2 = size.clip_line(pt1, pt2)
+      inside, new_pt1, new_pt2 = size.clip_line(pt1, pt2)
       assert_equal([true, 0, 8, 99, 91],
                    [
-                     ret,
+                     inside,
                      new_pt1.x,
                      new_pt1.y,
                      new_pt2.x,
@@ -39,10 +39,10 @@ class TestSize < Test::Unit::TestCase
       size = CV::Size.new(100, 100)
       pt1 = CV::Point.new(200, 200)
       pt2 = CV::Point.new(300, 300)
-      ret, new_pt1, new_pt2 = size.clip_line(pt1, pt2)
+      inside, new_pt1, new_pt2 = size.clip_line(pt1, pt2)
       assert_equal([false, 200, 200, 300, 300],
                    [
-                     ret,
+                     inside,
                      new_pt1.x,
                      new_pt1.y,
                      new_pt2.x,

--- a/test/test-size.rb
+++ b/test/test-size.rb
@@ -22,31 +22,31 @@ class TestSize < Test::Unit::TestCase
   sub_test_case("#clip_line") do
     def test_true
       size = CV::Size.new(100, 100)
-      pt1 = CV::Point.new(-10, 0)
-      pt2 = CV::Point.new(110, 100)
-      inside, new_pt1, new_pt2 = size.clip_line(pt1, pt2)
+      point1 = CV::Point.new(-10, 0)
+      point2 = CV::Point.new(110, 100)
+      inside, new_point1, new_point2 = size.clip_line(point1, point2)
       assert_equal([true, 0, 8, 99, 91],
                    [
                      inside,
-                     new_pt1.x,
-                     new_pt1.y,
-                     new_pt2.x,
-                     new_pt2.y
+                     new_point1.x,
+                     new_point1.y,
+                     new_point2.x,
+                     new_point2.y
                     ])
     end
 
     def test_false
       size = CV::Size.new(100, 100)
-      pt1 = CV::Point.new(200, 200)
-      pt2 = CV::Point.new(300, 300)
-      inside, new_pt1, new_pt2 = size.clip_line(pt1, pt2)
+      point1 = CV::Point.new(200, 200)
+      point2 = CV::Point.new(300, 300)
+      inside, new_point1, new_point2 = size.clip_line(point1, point2)
       assert_equal([false, 200, 200, 300, 300],
                    [
                      inside,
-                     new_pt1.x,
-                     new_pt1.y,
-                     new_pt2.x,
-                     new_pt2.y
+                     new_point1.x,
+                     new_point1.y,
+                     new_point2.x,
+                     new_point2.y
                     ])
     end
   end

--- a/test/test-size.rb
+++ b/test/test-size.rb
@@ -18,4 +18,36 @@ class TestSize < Test::Unit::TestCase
                    ])
     end
   end
+
+  sub_test_case("#clip_line") do
+    def test_true
+      size = CV::Size.new(100, 100)
+      pt1 = CV::Point.new(-10, 0)
+      pt2 = CV::Point.new(110, 100)
+      ret, new_pt1, new_pt2 = size.clip_line(pt1, pt2)
+      assert_equal([true, 0, 8, 99, 91],
+                   [
+                     ret,
+                     new_pt1.x,
+                     new_pt1.y,
+                     new_pt2.x,
+                     new_pt2.y
+                    ])
+    end
+
+    def test_false
+      size = CV::Size.new(100, 100)
+      pt1 = CV::Point.new(200, 200)
+      pt2 = CV::Point.new(300, 300)
+      ret, new_pt1, new_pt2 = size.clip_line(pt1, pt2)
+      assert_equal([false, 200, 200, 300, 300],
+                   [
+                     ret,
+                     new_pt1.x,
+                     new_pt1.y,
+                     new_pt2.x,
+                     new_pt2.y
+                    ])
+    end
+  end
 end


### PR DESCRIPTION
Add `gcv_size_clip_line()` and `gcv_rectangle_clip_line()` corresponding to:
* `bool cv::clipLine(Size imgSize, Point &pt1, Point &pt2)`
* `bool cv::clipLine(Rect imgRect, Point &pt1, Point &pt2)`
Actually they are not instance methods of class. I implemented them as instance methods of the class of the 1st argument. Is it OK?
