### PR TITLE
Add median_blur and split

### DIFF
--- a/opencv-glib/image-error.h
+++ b/opencv-glib/image-error.h
@@ -18,6 +18,7 @@ typedef enum {
   GCV_IMAGE_ERROR_READ,
   GCV_IMAGE_ERROR_WRITE,
   GCV_IMAGE_ERROR_UNKNOWN,
+  GCV_IMAGE_ERROR_FILTER,
 } GCVImageError;
 
 #define GCV_IMAGE_ERROR (gcv_image_error_quark())

--- a/opencv-glib/image-error.h
+++ b/opencv-glib/image-error.h
@@ -9,6 +9,7 @@ G_BEGIN_DECLS
  * @GCV_IMAGE_ERROR_READ: Read error.
  * @GCV_IMAGE_ERROR_WRITE: Write error.
  * @GCV_IMAGE_ERROR_UNKNOWN: Unknown error.
+ * @GCV_IMAGE_ERROR_FILTER: Filter error.
  *
  * Image related errors.
  *

--- a/opencv-glib/image.cpp
+++ b/opencv-glib/image.cpp
@@ -691,6 +691,8 @@ gcv_image_split(GCVImage *image)
 /**
  * gcv_image_median_blur:
  * @image: A #GCVImage.
+ * @ksize: Aperture linear size; it must be odd and greater than 1
+ * @error: (nullable): Return locatipcn for a #GError or %NULL.
  *
  * It effects median blur image. The converted image is returned as
  * a new image.
@@ -699,14 +701,22 @@ gcv_image_split(GCVImage *image)
  *
  * Since: 1.0.4
  */
-GCVImage *gcv_image_median_blur(GCVImage *image)
+GCVImage *gcv_image_median_blur(GCVImage *image,
+                                gint ksize,
+                                GError **error)
 {
   auto cv_image = gcv_matrix_get_raw(GCV_MATRIX(image));
   auto cv_converted_image = std::make_shared<cv::Mat>();
 
-  // TODO: * Use the arguments instead of static number.
-  //       * Change blur instead of medianBlur.
-  cv::medianBlur(*cv_image, *cv_converted_image, 3);
+  if (ksize % 2 == 0 || ksize < 1) {
+    g_set_error(error,
+                GCV_IMAGE_ERROR,
+                GCV_IMAGE_ERROR_FILTER,
+                "ksize must be odd and greater than 1");
+    return NULL;
+  }
+
+  cv::medianBlur(*cv_image, *cv_converted_image, ksize);
 
   return gcv_image_new_raw(&cv_converted_image);
 }

--- a/opencv-glib/image.cpp
+++ b/opencv-glib/image.cpp
@@ -675,24 +675,17 @@ GList *
 gcv_image_split(GCVImage *image)
 {
   auto cv_image = gcv_matrix_get_raw(GCV_MATRIX(image));
-  std::vector<cv::Mat> planes;
+  std::vector<cv::Mat> cv_splitted_images;
   GList *values = NULL;
-  int i;
 
-  cv::split(*cv_image,planes);
-
-  // TODO. get number of channels instead of 3
-  for( i = 0 ; i < 3 ; i++ ){
-    values = g_list_prepend(values,&planes[i]);
+  cv::split(*cv_image, cv_splitted_images);
+  for (const auto &cv_splitted_image : cv_splitted_images) {
+    auto cv_shared_splitted_image = std::make_shared<cv::Mat>(cv_splitted_image);
+    auto splitted_image = gcv_image_new_raw(&cv_shared_splitted_image);
+    values = g_list_prepend(values, splitted_image);
   }
-  values = g_list_prepend(values, NULL);
 
   return g_list_reverse(values);
-/*
-  cv::imwrite("/tmp/b.jpg",planes[0]);
-  cv::imwrite("/tmp/g.jpg",planes[1]);
-  cv::imwrite("/tmp/r.jpg",planes[2]);
-*/
 }
 
 /**

--- a/opencv-glib/image.cpp
+++ b/opencv-glib/image.cpp
@@ -732,4 +732,3 @@ gcv_image_new_raw(std::shared_ptr<cv::Mat> *cv_matrix)
                              NULL);
   return GCV_IMAGE(matrix);
 }
-

--- a/opencv-glib/image.cpp
+++ b/opencv-glib/image.cpp
@@ -7,6 +7,7 @@
 #include <opencv-glib/size.hpp>
 
 #include <opencv2/imgproc.hpp>
+#include <vector>
 
 G_BEGIN_DECLS
 
@@ -658,6 +659,65 @@ gcv_image_abs_diff(GCVImage *image,
   return gcv_image_new_raw(&cv_output);
 }
 
+/**
+ * gcv_image_split:
+ * @image: A #GCVImage.
+ *
+ * It splits image. The splitted image is returned as
+ * a new matrix.
+ *
+ * Returns: (element-type GCVImage) (transfer full):
+ *   The list of #GCVImage
+ *
+ * Since: 1.0.4
+ */
+GList *
+gcv_image_split(GCVImage *image)
+{
+  auto cv_image = gcv_matrix_get_raw(GCV_MATRIX(image));
+  std::vector<cv::Mat> planes;
+  GList *values = NULL;
+  int i;
+
+  cv::split(*cv_image,planes);
+
+  // TODO. get number of channels instead of 3
+  for( i = 0 ; i < 3 ; i++ ){
+    values = g_list_prepend(values,&planes[i]);
+  }
+  values = g_list_prepend(values, NULL);
+
+  return g_list_reverse(values);
+/*
+  cv::imwrite("/tmp/b.jpg",planes[0]);
+  cv::imwrite("/tmp/g.jpg",planes[1]);
+  cv::imwrite("/tmp/r.jpg",planes[2]);
+*/
+}
+
+/**
+ * gcv_image_median_blur:
+ * @image: A #GCVImage.
+ *
+ * It effects median blur image. The converted image is returned as
+ * a new image.
+ *
+ * Returns: (transfer full): A converted #GCVImage.
+ *
+ * Since: 1.0.4
+ */
+GCVImage *gcv_image_median_blur(GCVImage *image)
+{
+  auto cv_image = gcv_matrix_get_raw(GCV_MATRIX(image));
+  auto cv_converted_image = std::make_shared<cv::Mat>();
+
+  // TODO: * Use the arguments instead of static number.
+  //       * Change blur instead of medianBlur.
+  cv::medianBlur(*cv_image, *cv_converted_image, 3);
+
+  return gcv_image_new_raw(&cv_converted_image);
+}
+
 G_END_DECLS
 
 GCVImage *
@@ -668,3 +728,4 @@ gcv_image_new_raw(std::shared_ptr<cv::Mat> *cv_matrix)
                              NULL);
   return GCV_IMAGE(matrix);
 }
+

--- a/opencv-glib/image.cpp
+++ b/opencv-glib/image.cpp
@@ -712,7 +712,8 @@ GCVImage *gcv_image_median_blur(GCVImage *image,
     g_set_error(error,
                 GCV_IMAGE_ERROR,
                 GCV_IMAGE_ERROR_FILTER,
-                "ksize must be odd and greater than 1");
+                "ksize must be odd and greater than 1: <%d>",
+                ksize);
     return NULL;
   }
 

--- a/opencv-glib/image.h
+++ b/opencv-glib/image.h
@@ -231,6 +231,8 @@ gcv_image_abs_diff(GCVImage *image,
 
 GList *gcv_image_split(GCVImage *image);
 
-GCVImage *gcv_image_median_blur(GCVImage *image);
+GCVImage *gcv_image_median_blur(GCVImage *image,
+                                gint ksize,
+                                GError **error);
 
 G_END_DECLS

--- a/opencv-glib/image.h
+++ b/opencv-glib/image.h
@@ -229,4 +229,8 @@ GCVImage *
 gcv_image_abs_diff(GCVImage *image,
                    GCVImage *other_image);
 
+GList *gcv_image_split(GCVImage *image);
+
+GCVImage *gcv_image_median_blur(GCVImage *image);
+
 G_END_DECLS

--- a/test/run-test.rb
+++ b/test/run-test.rb
@@ -1,6 +1,8 @@
 #!/usr/bin/env ruby
 
 require "pathname"
+
+gem "test-unit"
 require "test-unit"
 
 base_dir = Pathname(__dir__).parent

--- a/test/test-image.rb
+++ b/test/test-image.rb
@@ -339,5 +339,20 @@ class TestImage < Test::Unit::TestCase
                    ],
                    splitted_image_data)
     end
+
+    def test_median_blur
+      blur_image = @image.median_blur(7)
+      assert_not_equal(@image.bytes.to_s,
+                       blur_image.bytes.to_s)
+    end
+
+    def test_median_blur_invalid_argument
+      # ksize must be odd and greater than 1
+      [-1,0,2].each do |n|
+        assert_raise(CV::ImageError::Filter) do
+          @image.median_blur(n)
+        end
+      end
+    end
   end
 end

--- a/test/test-image.rb
+++ b/test/test-image.rb
@@ -323,5 +323,21 @@ class TestImage < Test::Unit::TestCase
       assert_equal(expected.bytes.to_s,
                    @image.abs_diff(lined_image).bytes.to_s)
     end
+
+    def test_split
+      spliited_data = @image.bytes.to_s.each_char.group_by.with_index do |_, i|
+        i % 4
+      end
+      splitted_image_data = @image.split.collect do |splitted_image|
+        splitted_image.bytes.to_s
+      end
+      assert_equal([
+                     spliited_data[0].join(""),
+                     spliited_data[1].join(""),
+                     spliited_data[2].join(""),
+                     spliited_data[3].join(""),
+                   ],
+                   splitted_image_data)
+    end
   end
 end

--- a/test/test-image.rb
+++ b/test/test-image.rb
@@ -346,12 +346,12 @@ class TestImage < Test::Unit::TestCase
                        blur_image.bytes.to_s)
     end
 
-    def test_median_blur_invalid_argument
-      # ksize must be odd and greater than 1
-      [-1,0,2].each do |n|
-        assert_raise(CV::ImageError::Filter) do
-          @image.median_blur(n)
-        end
+    data(:ksize, [-1, 0, 2])
+    def test_median_blur_invalid_argument(data)
+      ksize = data[:ksize]
+      message = "ksize must be odd and greater than 1: <#{ksize}>"
+      assert_raise(CV::ImageError::Filter.new(message)) do
+        @image.median_blur(ksize)
       end
     end
   end


### PR DESCRIPTION
@kou Could you tell me how to implement `cv::split` using gobject-introspection?

Especially, this part.
https://github.com/red-data-tools/opencv-glib/compare/master...hiroyuki-sato:topic/wip-blur-split?expand=1#diff-997f5a049791d6fd1528a5d80877a100e3eb23b2ad7917cdb30fec66d28d6c3eR686

Best regards