### PR TITLE
test: add support for running with rbenv on macOS

### DIFF
--- a/test/run-test.sh
+++ b/test/run-test.sh
@@ -13,7 +13,9 @@ for module in ${modules}; do
   module_build_dir="${build_dir}/${module}"
   if [ -d "${module_build_dir}" ]; then
     LD_LIBRARY_PATH="${module_build_dir}:${LD_LIBRARY_PATH}"
+    DYLD_LIBRARY_PATH="${module_build_dir}:${DYLD_LIBRARY_PATH}"
     export LD_LIBRARY_PATH
+    export DYLD_LIBRARY_PATH
   fi
 
   module_typelib_dir="${build_dir}/${module}"

--- a/test/run-test.sh
+++ b/test/run-test.sh
@@ -25,4 +25,10 @@ for module in ${modules}; do
   fi
 done
 
-${GDB} ruby ${test_dir}/run-test.rb "$@"
+if rbenv version > /dev/null 2>&1; then
+  ruby=$(rbenv which ruby)
+else
+  ruby=ruby
+fi
+
+${GDB} ${ruby} ${test_dir}/run-test.rb "$@"


### PR DESCRIPTION
This PR fixed the following error on the macOS build.

Thanks! 
* [@kou](https://gitter.im/red-data-tools/ja?at=62211bf2c435002500d3d003)
* [Kenta Murata](https://gitter.im/red-data-tools/ja?at=62216ce1090925231809bdf6)
* [Kazuhiro NISHIYAMA](https://gitter.im/red-data-tools/ja?at=622170f999d94f5f0c33ad76)

```
sh ../test/run-test.sh
ninja: no work to do.
(null)-WARNING **: Failed to load shared library 'libopencv-glib.1.dylib' referenced by the typelib: dlopen(libopencv-glib.1.dylib, 0x0009): tried: 'libopencv-glib.1.dylib' (no such file), '/usr/local/lib/libopencv-glib.1.dylib' (no such file), '/usr/lib/libopencv-glib.1.dylib' (no such file), '/path/to/red-data-tools/opencv-glib/build/libopencv-glib.1.dylib' (no such file), '/usr/local/lib/libopencv-glib.1.dylib' (no such file), '/usr/lib/libopencv-glib.1.dylib' (no such file)
	from /Users/user/.rbenv/versions/3.0.2/lib/ruby/gems/3.0.0/gems/gobject-introspection-3.5.1/lib/gobject-introspection/loader.rb:234:in `load_object_info'
	from /Users/user/.rbenv/versions/3.0.2/lib/ruby/gems/3.0.0/gems/gobject-introspection-3.5.1/lib/gobject-introspection/loader.rb:73:in `load_info'
	from /Users/user/.rbenv/versions/3.0.2/lib/ruby/gems/3.0.0/gems/gobject-introspection-3.5.1/lib/gobject-introspection/loader.rb:47:in `block (2 levels) in load'
	from /Users/user/.rbenv/versions/3.0.2/lib/ruby/gems/3.0.0/gems/gobject-introspection-3.5.1/lib/gobject-introspection/repository.rb:34:in `block (2 levels) in each'
	from /Users/user/.rbenv/versions/3.0.2/lib/ruby/gems/3.0.0/gems/gobject-introspection-3.5.1/lib/gobject-introspection/repository.rb:33:in `times'
	from /Users/user/.rbenv/versions/3.0.2/lib/ruby/gems/3.0.0/gems/gobject-introspection-3.5.1/lib/gobject-introspection/repository.rb:33:in `block in each'
	from /Users/user/.rbenv/versions/3.0.2/lib/ruby/gems/3.0.0/gems/gobject-introspection-3.5.1/lib/gobject-introspection/repository.rb:32:in `each'
	from /Users/user/.rbenv/versions/3.0.2/lib/ruby/gems/3.0.0/gems/gobject-introspection-3.5.1/lib/gobject-introspection/repository.rb:32:in `each'
	from /Users/user/.rbenv/versions/3.0.2/lib/ruby/gems/3.0.0/gems/gobject-introspection-3.5.1/lib/gobject-introspection/loader.rb:46:in `block in load'
	from /Users/user/.rbenv/versions/3.0.2/lib/ruby/gems/3.0.0/gems/gobject-introspection-3.5.1/lib/gobject-introspection/loader.rb:622:in `prepare_class'
	from /Users/user/.rbenv/versions/3.0.2/lib/ruby/gems/3.0.0/gems/gobject-introspection-3.5.1/lib/gobject-introspection/loader.rb:41:in `load'
	from /Users/user/.rbenv/versions/3.0.2/lib/ruby/gems/3.0.0/gems/gobject-introspection-3.5.1/lib/gobject-introspection.rb:44:in `load'
	from /path/to/red-data-tools/opencv-glib/test/run-test.rb:13:in `<main>'
Loaded suite test
Started
E
==============================================================================
Error: test_brightness(TestColor::.new): NameError: uninitialized constant CV::Color
/path/to/red-data-tools/opencv-glib/test/test-color.rb:4:in `test_brightness'
     1: class TestColor < Test::Unit::TestCase
     2:   sub_test_case(".new") do
     3:     def test_brightness
  => 4:       color = CV::Color.new(0.9)
     5:       assert_equal(0.9, color.brightness)
     6:     end
     7:
==============================================================================
E
```