### PR TITLE
Fix Arch Linux build

### DIFF
--- a/dockerfiles/arch-linux.dockerfile
+++ b/dockerfiles/arch-linux.dockerfile
@@ -3,15 +3,20 @@ FROM archlinux
 RUN \
   pacman --sync --noconfirm --refresh && \
   pacman --sync --noconfirm \
+    fmt \
     gcc \
     git \
     glew \
     gobject-introspection \
     hdf5 \
+    jack2 \
+    jsoncpp \
     make \
     meson \
     opencv \
+    openmpi \
     pkg-config \
+    pugixml \
     qt5 \
     ruby \
     sudo \


### PR DESCRIPTION
This PR fixes the following CI error on Arch Linux.

```
[17/18] Generating opencv-glib/CV-1.0.gir with a custom command
[52](https://github.com/red-data-tools/opencv-glib/runs/5416283947?check_suite_focus=true#step:4:52)
FAILED: opencv-glib/CV-1.0.gir 
[53](https://github.com/red-data-tools/opencv-glib/runs/5416283947?check_suite_focus=true#step:4:53)
/usr/bin/g-ir-scanner --no-libtool --namespace=CV --nsversion=1.0 --warn-all --output opencv-glib/CV-1.0.gir --warn-all -I/home/opencv-glib/opencv-glib/opencv-glib -I/home/opencv-glib/opencv-glib.build/opencv-glib -I/home/opencv-glib/opencv-glib/. -I/home/opencv-glib/opencv-glib.build/. --filelist=/home/opencv-glib/opencv-glib.build/opencv-glib/libopencv-glib.so.1.0.0.p/CV_1.0_gir_filelist --include=GObject-2.0 --symbol-prefix=gcv --identifier-prefix=GCV --pkg-export=opencv-glib --cflags-begin -I/home/opencv-glib/opencv-glib/. -I/home/opencv-glib/opencv-glib.build/. -I/usr/include/opencv4 -I/usr/include/glib-2.0 -I/usr/lib/glib-2.0/include -I/usr/include/sysprof-4 -I/usr/include/gobject-introspection-1.0 --cflags-end --add-include-path=/usr/share/gir-1.0 -L/home/opencv-glib/opencv-glib.build/opencv-glib --library opencv-glib --extra-library=opencv_gapi --extra-library=opencv_stitching --extra-library=opencv_alphamat --extra-library=opencv_aruco --extra-library=opencv_barcode --extra-library=opencv_bgsegm --extra-library=opencv_bioinspired --extra-library=opencv_ccalib --extra-library=opencv_cvv --extra-library=opencv_dnn_objdetect --extra-library=opencv_dnn_superres --extra-library=opencv_dpm --extra-library=opencv_face --extra-library=opencv_freetype --extra-library=opencv_fuzzy --extra-library=opencv_hdf --extra-library=opencv_hfs --extra-library=opencv_img_hash --extra-library=opencv_intensity_transform --extra-library=opencv_line_descriptor --extra-library=opencv_mcc --extra-library=opencv_quality --extra-library=opencv_rapid --extra-library=opencv_reg --extra-library=opencv_rgbd --extra-library=opencv_saliency --extra-library=opencv_stereo --extra-library=opencv_structured_light --extra-library=opencv_phase_unwrapping --extra-library=opencv_superres --extra-library=opencv_optflow --extra-library=opencv_surface_matching --extra-library=opencv_tracking --extra-library=opencv_highgui --extra-library=opencv_datasets --extra-library=opencv_text --extra-library=opencv_plot --extra-library=opencv_videostab --extra-library=opencv_videoio --extra-library=opencv_viz --extra-library=opencv_wechat_qrcode --extra-library=opencv_xfeatures2d --extra-library=opencv_shape --extra-library=opencv_ml --extra-library=opencv_ximgproc --extra-library=opencv_video --extra-library=opencv_xobjdetect --extra-library=opencv_objdetect --extra-library=opencv_calib3d --extra-library=opencv_imgcodecs --extra-library=opencv_features2d --extra-library=opencv_dnn --extra-library=opencv_flann --extra-library=opencv_xphoto --extra-library=opencv_photo --extra-library=opencv_imgproc --extra-library=opencv_core --extra-library=gobject-2.0 --extra-library=glib-2.0 --extra-library=girepository-1.0 --sources-top-dirs /home/opencv-glib/opencv-glib/subprojects/ --sources-top-dirs /home/opencv-glib/opencv-glib.build/subprojects/
[54](https://github.com/red-data-tools/opencv-glib/runs/5416283947?check_suite_focus=true#step:4:54)
g-ir-scanner: link: gcc -pthread -o /home/opencv-glib/opencv-glib.build/tmp-introspect4re1m77m/CV-1.0 /home/opencv-glib/opencv-glib.build/tmp-introspect4re1m77m/CV-1.0.o -L. -Wl,-rpath,. -Wl,--no-as-needed -L/home/opencv-glib/opencv-glib.build/opencv-glib -Wl,-rpath,/home/opencv-glib/opencv-glib.build/opencv-glib -lopencv-glib -lopencv_gapi -lopencv_stitching -lopencv_alphamat -lopencv_aruco -lopencv_barcode -lopencv_bgsegm -lopencv_bioinspired -lopencv_ccalib -lopencv_cvv -lopencv_dnn_objdetect -lopencv_dnn_superres -lopencv_dpm -lopencv_face -lopencv_freetype -lopencv_fuzzy -lopencv_hdf -lopencv_hfs -lopencv_img_hash -lopencv_intensity_transform -lopencv_line_descriptor -lopencv_mcc -lopencv_quality -lopencv_rapid -lopencv_reg -lopencv_rgbd -lopencv_saliency -lopencv_stereo -lopencv_structured_light -lopencv_phase_unwrapping -lopencv_superres -lopencv_optflow -lopencv_surface_matching -lopencv_tracking -lopencv_highgui -lopencv_datasets -lopencv_text -lopencv_plot -lopencv_videostab -lopencv_videoio -lopencv_viz -lopencv_wechat_qrcode -lopencv_xfeatures2d -lopencv_shape -lopencv_ml -lopencv_ximgproc -lopencv_video -lopencv_xobjdetect -lopencv_objdetect -lopencv_calib3d -lopencv_imgcodecs -lopencv_features2d -lopencv_dnn -lopencv_flann -lopencv_xphoto -lopencv_photo -lopencv_imgproc -lopencv_core -lgobject-2.0 -lglib-2.0 -lgirepository-1.0 -lgio-2.0 -lgobject-2.0 -Wl,--export-dynamic -lgmodule-2.0 -pthread -lglib-2.0 -lglib-2.0
[55](https://github.com/red-data-tools/opencv-glib/runs/5416283947?check_suite_focus=true#step:4:55)
/usr/sbin/ld: warning: libjsoncpp.so.25, needed by /usr/lib/libvtkIOExport.so.1, not found (try using -rpath or -rpath-link)
[56](https://github.com/red-data-tools/opencv-glib/runs/5416283947?check_suite_focus=true#step:4:56)
/usr/sbin/ld: warning: libpugixml.so.1, needed by /usr/lib/libvtkIOImage.so.1, not found (try using -rpath or -rpath-link)
[57](https://github.com/red-data-tools/opencv-glib/runs/5416283947?check_suite_focus=true#step:4:57)
/usr/sbin/ld: warning: libmpi.so.40, needed by /usr/lib/libvtkFiltersExtraction.so.1, not found (try using -rpath or -rpath-link)
[58](https://github.com/red-data-tools/opencv-glib/runs/5416283947?check_suite_focus=true#step:4:58)
/usr/sbin/ld: warning: libfmt.so.8, needed by /usr/lib/libvtkFiltersGeneral.so.1, not found (try using -rpath or -rpath-link)
[59](https://github.com/red-data-tools/opencv-glib/runs/5416283947?check_suite_focus=true#step:4:59)
/usr/sbin/ld: /usr/lib/libvtkIOExport.so.1: undefined reference to `Json::StreamWriterBuilder::operator[](std::__cxx11::basic_string<char, std::char_traits<char>, std::allocator<char> > const&)'
[60](https://github.com/red-data-tools/opencv-glib/runs/5416283947?check_suite_focus=true#step:4:60)
/usr/sbin/ld: /usr/lib/libvtkParallelMPI.so.1: undefined reference to `ompi_mpi_unsigned'
[61](https://github.com/red-data-tools/opencv-glib/runs/5416283947?check_suite_focus=true#step:4:61)
/usr/sbin/ld: /usr/lib/libvtkCommonDataModel.so.1: undefined reference to `pugi::xml_tree_walker::begin(pugi::xml_node&)'
[62](https://github.com/red-data-tools/opencv-glib/runs/5416283947?check_suite_focus=true#step:4:62)
/usr/sbin/ld: /usr/lib/libvtkParallelMPI.so.1: undefined reference to `ompi_mpi_short'
[63](https://github.com/red-data-tools/opencv-glib/runs/5416283947?check_suite_focus=true#step:4:63)
/usr/sbin/ld: /usr/lib/libvtkCommonDataModel.so.1: undefined reference to `pugi::xml_attribute::set_value(char const*)'
[64](https://github.com/red-data-tools/opencv-glib/runs/5416283947?check_suite_focus=true#step:4:64)
/usr/sbin/ld: /usr/lib/libvtkIOExport.so.1: undefined reference to `Json::Value::~Value()'
[65](https://github.com/red-data-tools/opencv-glib/runs/5416283947?check_suite_focus=true#step:4:65)
/usr/sbin/ld: /usr/lib/libvtkCommonDataModel.so.1: undefined reference to `pugi::xml_node::name() const'
[66](https://github.com/red-data-tools/opencv-glib/runs/5416283947?check_suite_focus=true#step:4:66)
/usr/sbin/ld: /usr/lib/libvtkIOGeometry.so.1: undefined reference to `Json::Value::begin() const'
[67](https://github.com/red-data-tools/opencv-glib/runs/5416283947?check_suite_focus=true#step:4:67)
/usr/sbin/ld: /usr/lib/libvtkIOGeometry.so.1: undefined reference to `Json::Value::isString() const'
[68](https://github.com/red-data-tools/opencv-glib/runs/5416283947?check_suite_focus=true#step:4:68)
/usr/sbin/ld: /usr/lib/libvtkCommonDataModel.so.1: undefined reference to `pugi::xml_attribute::set_value(unsigned int)'
[69](https://github.com/red-data-tools/opencv-glib/runs/5416283947?check_suite_focus=true#step:4:69)
/usr/sbin/ld: /usr/lib/libvtkParallelMPI.so.1: undefined reference to `ompi_mpi_op_bor'
[70](https://github.com/red-data-tools/opencv-glib/runs/5416283947?check_suite_focus=true#step:4:70)
/usr/sbin/ld: /usr/lib/libvtkIOGeometry.so.1: undefined reference to `Json::Value::asBool() const'
[71](https://github.com/red-data-tools/opencv-glib/runs/5416283947?check_suite_focus=true#step:4:71)
/usr/sbin/ld: /usr/lib/libvtkCommonDataModel.so.1: undefined reference to `pugi::xml_attribute_iterator::operator!=(pugi::xml_attribute_iterator const&) const'
[72](https://github.com/red-data-tools/opencv-glib/runs/5416283947?check_suite_focus=true#step:4:72)
/usr/sbin/ld: /usr/lib/libvtkCommonDataModel.so.1: undefined reference to `pugi::xml_node::operator==(pugi::xml_node const&) const'
[73](https://github.com/red-data-tools/opencv-glib/runs/5416283947?check_suite_focus=true#step:4:73)
/usr/sbin/ld: /usr/lib/libvtkIOImage.so.1: undefined reference to `pugi::xml_node_iterator::operator*() const'
[74](https://github.com/red-data-tools/opencv-glib/runs/5416283947?check_suite_focus=true#step:4:74)
/usr/sbin/ld: /usr/lib/libvtkParallelMPI.so.1: undefined reference to `MPI_Scatterv'
[75](https://github.com/red-data-tools/opencv-glib/runs/5416283947?check_suite_focus=true#step:4:75)
/usr/sbin/ld: /usr/lib/libvtkIOExport.so.1: undefined reference to `Json::Value::append(Json::Value const&)'
[76](https://github.com/red-data-tools/opencv-glib/runs/5416283947?check_suite_focus=true#step:4:76)
/usr/sbin/ld: /usr/lib/libvtkParallelMPI.so.1: undefined reference to `ompi_mpi_op_prod'
[77](https://github.com/red-data-tools/opencv-glib/runs/5416283947?check_suite_focus=true#step:4:77)
/usr/sbin/ld: /usr/lib/libvtkFiltersExtraction.so.1: undefined reference to `MPI_Issend'
[78](https://github.com/red-data-tools/opencv-glib/runs/5416283947?check_suite_focus=true#step:4:78)
/usr/sbin/ld: /usr/lib/libvtkIOGeometry.so.1: undefined reference to `Json::CharReaderBuilder::CharReaderBuilder()'
[79](https://github.com/red-data-tools/opencv-glib/runs/5416283947?check_suite_focus=true#step:4:79)
/usr/sbin/ld: /usr/lib/libvtkCommonDataModel.so.1: undefined reference to `pugi::xml_attribute::as_uint(unsigned int) const'
[80](https://github.com/red-data-tools/opencv-glib/runs/5416283947?check_suite_focus=true#step:4:80)
/usr/sbin/ld: /usr/lib/libvtkParallelMPI.so.1: undefined reference to `ompi_mpi_unsigned_char'
[81](https://github.com/red-data-tools/opencv-glib/runs/5416283947?check_suite_focus=true#step:4:81)
/usr/sbin/ld: /usr/lib/libvtkParallelMPI.so.1: undefined reference to `MPI_Error_string'
[82](https://github.com/red-data-tools/opencv-glib/runs/5416283947?check_suite_focus=true#step:4:82)
/usr/sbin/ld: /usr/lib/libvtkIOImage.so.1: undefined reference to `pugi::xml_node::end() const'
[83](https://github.com/red-data-tools/opencv-glib/runs/5416283947?check_suite_focus=true#step:4:83)
/usr/sbin/ld: /usr/lib/libvtkParallelDIY.so.1: undefined reference to `ompi_mpi_unsigned_long'
[84](https://github.com/red-data-tools/opencv-glib/runs/5416283947?check_suite_focus=true#step:4:84)
/usr/sbin/ld: /usr/lib/libvtkParallelMPI.so.1: undefined reference to `ompi_mpi_signed_char'
[85](https://github.com/red-data-tools/opencv-glib/runs/5416283947?check_suite_focus=true#step:4:85)
/usr/sbin/ld: /usr/lib/libvtkIOExport.so.1: undefined reference to `Json::Value::Value(unsigned int)'
[86](https://github.com/red-data-tools/opencv-glib/runs/5416283947?check_suite_focus=true#step:4:86)
/usr/sbin/ld: /usr/lib/libvtkIOGeometry.so.1: undefined reference to `Json::Value::isUInt() const'
[87](https://github.com/red-data-tools/opencv-glib/runs/5416283947?check_suite_focus=true#step:4:87)
/usr/sbin/ld: /usr/lib/libvtkCommonDataModel.so.1: undefined reference to `pugi::xml_attribute::as_float(float) const'
[88](https://github.com/red-data-tools/opencv-glib/runs/5416283947?check_suite_focus=true#step:4:88)
/usr/sbin/ld: /usr/lib/libvtkFiltersExtraction.so.1: undefined reference to `MPI_Recv'
[89](https://github.com/red-data-tools/opencv-glib/runs/5416283947?check_suite_focus=true#step:4:89)
/usr/sbin/ld: /usr/lib/libvtkIOGeometry.so.1: undefined reference to `Json::Value::begin()'
[90](https://github.com/red-data-tools/opencv-glib/runs/5416283947?check_suite_focus=true#step:4:90)
/usr/sbin/ld: /usr/lib/libvtkCommonDataModel.so.1: undefined reference to `pugi::xml_node::parent() const'
[91](https://github.com/red-data-tools/opencv-glib/runs/5416283947?check_suite_focus=true#step:4:91)
/usr/sbin/ld: /usr/lib/libvtkCommonDataModel.so.1: undefined reference to `pugi::xml_attribute::operator=(unsigned int)'
[92](https://github.com/red-data-tools/opencv-glib/runs/5416283947?check_suite_focus=true#step:4:92)
/usr/sbin/ld: /usr/lib/libvtkIOImage.so.1: undefined reference to `pugi::xml_document::xml_document()'
[93](https://github.com/red-data-tools/opencv-glib/runs/5416283947?check_suite_focus=true#step:4:93)
/usr/sbin/ld: /usr/lib/libvtkIOExport.so.1: undefined reference to `Json::Value::operator=(Json::Value&&)'
[94](https://github.com/red-data-tools/opencv-glib/runs/5416283947?check_suite_focus=true#step:4:94)
/usr/sbin/ld: /usr/lib/libvtkIOImage.so.1: undefined reference to `pugi::xml_document::load_buffer(void const*, unsigned long, unsigned int, pugi::xml_encoding)'
[95](https://github.com/red-data-tools/opencv-glib/runs/5416283947?check_suite_focus=true#step:4:95)
/usr/sbin/ld: /usr/lib/libvtkIOGeometry.so.1: undefined reference to `Json::Value::end()'
[96](https://github.com/red-data-tools/opencv-glib/runs/5416283947?check_suite_focus=true#step:4:96)
/usr/sbin/ld: /usr/lib/libvtkCommonDataModel.so.1: undefined reference to `pugi::xml_tree_walker::xml_tree_walker()'
[97](https://github.com/red-data-tools/opencv-glib/runs/5416283947?check_suite_focus=true#step:4:97)
/usr/sbin/ld: /usr/lib/libvtkCommonDataModel.so.1: undefined reference to `pugi::xml_attribute::as_llong(long long) const'
[98](https://github.com/red-data-tools/opencv-glib/runs/5416283947?check_suite_focus=true#step:4:98)
/usr/sbin/ld: /usr/lib/libvtkParallelMPI.so.1: undefined reference to `MPI_Request_free'
[99](https://github.com/red-data-tools/opencv-glib/runs/5416283947?check_suite_focus=true#step:4:99)
/usr/sbin/ld: /usr/lib/libvtkIOImage.so.1: undefined reference to `pugi::xml_node::operator!() const'
[100](https://github.com/red-data-tools/opencv-glib/runs/5416283947?check_suite_focus=true#step:4:100)
/usr/sbin/ld: /usr/lib/libvtkRenderingVtkJS.so.1: undefined reference to `Json::Value::operator==(Json::Value const&) const'
[201](https://github.com/red-data-tools/opencv-glib/runs/5416283947?check_suite_focus=true#step:4:201)
/usr/sbin/ld: /usr/lib/libvtkCommonDataModel.so.1: undefined reference to `pugi::xml_node::select_nodes(char const*, pugi::xpath_variable_set*) const'
[202](https://github.com/red-data-tools/opencv-glib/runs/5416283947?check_suite_focus=true#step:4:202)
/usr/sbin/ld: /usr/lib/libvtkCommonDataModel.so.1: undefined reference to `pugi::xml_node::first_child() const'
[203](https://github.com/red-data-tools/opencv-glib/runs/5416283947?check_suite_focus=true#step:4:203)
/usr/sbin/ld: /usr/lib/libvtkIOExport.so.1: undefined reference to `Json::Value::operator[](unsigned int)'
[204](https://github.com/red-data-tools/opencv-glib/runs/5416283947?check_suite_focus=true#step:4:204)
/usr/sbin/ld: /usr/lib/libvtkParallelDIY.so.1: undefined reference to `ompi_mpi_double'
[205](https://github.com/red-data-tools/opencv-glib/runs/5416283947?check_suite_focus=true#step:4:205)
/usr/sbin/ld: /usr/lib/libvtkFiltersExtraction.so.1: undefined reference to `MPI_Get_count'
[206](https://github.com/red-data-tools/opencv-glib/runs/5416283947?check_suite_focus=true#step:4:206)
/usr/sbin/ld: /usr/lib/libvtkIOGeometry.so.1: undefined reference to `Json::Value::isBool() const'
[207](https://github.com/red-data-tools/opencv-glib/runs/5416283947?check_suite_focus=true#step:4:207)
/usr/sbin/ld: /usr/lib/libvtkParallelMPI.so.1: undefined reference to `ompi_mpi_op_land'
[208](https://github.com/red-data-tools/opencv-glib/runs/5416283947?check_suite_focus=true#step:4:208)
/usr/sbin/ld: /usr/lib/libvtkParallelMPI.so.1: undefined reference to `MPI_Errhandler_free'
[209](https://github.com/red-data-tools/opencv-glib/runs/5416283947?check_suite_focus=true#step:4:209)
/usr/sbin/ld: /usr/lib/libvtkParallelMPI.so.1: undefined reference to `MPI_Group_incl'
[210](https://github.com/red-data-tools/opencv-glib/runs/5416283947?check_suite_focus=true#step:4:210)
/usr/sbin/ld: /usr/lib/libvtkParallelDIY.so.1: undefined reference to `MPI_Bcast'
[211](https://github.com/red-data-tools/opencv-glib/runs/5416283947?check_suite_focus=true#step:4:211)
/usr/sbin/ld: /usr/lib/libvtkCommonDataModel.so.1: undefined reference to `pugi::xml_node::append_child(char const*)'
[212](https://github.com/red-data-tools/opencv-glib/runs/5416283947?check_suite_focus=true#step:4:212)
/usr/sbin/ld: /usr/lib/libvtkCommonDataModel.so.1: undefined reference to `pugi::xpath_node_set::begin() const'
[213](https://github.com/red-data-tools/opencv-glib/runs/5416283947?check_suite_focus=true#step:4:213)
/usr/sbin/ld: /usr/lib/libvtkCommonDataModel.so.1: undefined reference to `pugi::xml_node::xml_node()'
[214](https://github.com/red-data-tools/opencv-glib/runs/5416283947?check_suite_focus=true#step:4:214)
/usr/sbin/ld: /usr/lib/libvtkParallelMPI.so.1: undefined reference to `MPI_Scatter'
[215](https://github.com/red-data-tools/opencv-glib/runs/5416283947?check_suite_focus=true#step:4:215)
/usr/sbin/ld: /usr/lib/libvtkCommonDataModel.so.1: undefined reference to `pugi::xml_node::children(char const*) const'
[216](https://github.com/red-data-tools/opencv-glib/runs/5416283947?check_suite_focus=true#step:4:216)
/usr/sbin/ld: /usr/lib/libvtkIOExport.so.1: undefined reference to `Json::Value::Value(Json::ValueType)'
[217](https://github.com/red-data-tools/opencv-glib/runs/5416283947?check_suite_focus=true#step:4:217)
/usr/sbin/ld: /usr/lib/libvtkIOGeometry.so.1: undefined reference to `Json::Value::asInt() const'
[218](https://github.com/red-data-tools/opencv-glib/runs/5416283947?check_suite_focus=true#step:4:218)
/usr/sbin/ld: /usr/lib/libvtkIOExport.so.1: undefined reference to `Json::Value::empty() const'
[219](https://github.com/red-data-tools/opencv-glib/runs/5416283947?check_suite_focus=true#step:4:219)
/usr/sbin/ld: /usr/lib/libvtkIOGeometry.so.1: undefined reference to `Json::ValueIteratorBase::deref() const'
[220](https://github.com/red-data-tools/opencv-glib/runs/5416283947?check_suite_focus=true#step:4:220)
/usr/sbin/ld: /usr/lib/libvtkCommonDataModel.so.1: undefined reference to `typeinfo for pugi::xpath_exception'
[221](https://github.com/red-data-tools/opencv-glib/runs/5416283947?check_suite_focus=true#step:4:221)
/usr/sbin/ld: /usr/lib/libvtkParallelMPI.so.1: undefined reference to `MPI_Cancel'
[222](https://github.com/red-data-tools/opencv-glib/runs/5416283947?check_suite_focus=true#step:4:222)
/usr/sbin/ld: /usr/lib/libvtkIOGeometry.so.1: undefined reference to `Json::Value::end() const'
[223](https://github.com/red-data-tools/opencv-glib/runs/5416283947?check_suite_focus=true#step:4:223)
/usr/sbin/ld: /usr/lib/libvtkCommonDataModel.so.1: undefined reference to `pugi::xml_tree_walker::~xml_tree_walker()'
[224](https://github.com/red-data-tools/opencv-glib/runs/5416283947?check_suite_focus=true#step:4:224)
/usr/sbin/ld: /usr/lib/libvtkParallelMPI.so.1: undefined reference to `MPI_Send'
[225](https://github.com/red-data-tools/opencv-glib/runs/5416283947?check_suite_focus=true#step:4:225)
/usr/sbin/ld: /usr/lib/libvtkIOGeometry.so.1: undefined reference to `Json::Value::operator[](std::__cxx11::basic_string<char, std::char_traits<char>, std::allocator<char> > const&) const'
[226](https://github.com/red-data-tools/opencv-glib/runs/5416283947?check_suite_focus=true#step:4:226)
/usr/sbin/ld: /usr/lib/libvtkParallelDIY.so.1: undefined reference to `ompi_mpi_op_min'
[227](https://github.com/red-data-tools/opencv-glib/runs/5416283947?check_suite_focus=true#step:4:227)
/usr/sbin/ld: /usr/lib/libvtkCommonDataModel.so.1: undefined reference to `pugi::xml_tree_walker::end(pugi::xml_node&)'
[228](https://github.com/red-data-tools/opencv-glib/runs/5416283947?check_suite_focus=true#step:4:228)
/usr/sbin/ld: /usr/lib/libvtkIOImage.so.1: undefined reference to `pugi::xml_attribute::as_string(char const*) const'
[229](https://github.com/red-data-tools/opencv-glib/runs/5416283947?check_suite_focus=true#step:4:229)
/usr/sbin/ld: /usr/lib/libvtkIOImage.so.1: undefined reference to `pugi::xml_node::operator void (*)(pugi::xml_node***)() const'
[230](https://github.com/red-data-tools/opencv-glib/runs/5416283947?check_suite_focus=true#step:4:230)
/usr/sbin/ld: /usr/lib/libvtkParallelMPI.so.1: undefined reference to `MPI_Irecv'
[231](https://github.com/red-data-tools/opencv-glib/runs/5416283947?check_suite_focus=true#step:4:231)
/usr/sbin/ld: /usr/lib/libvtkFiltersExtraction.so.1: undefined reference to `ompi_mpi_comm_world'
[232](https://github.com/red-data-tools/opencv-glib/runs/5416283947?check_suite_focus=true#step:4:232)
/usr/sbin/ld: /usr/lib/libvtkCommonDataModel.so.1: undefined reference to `pugi::xml_node::remove_attribute(pugi::xml_attribute const&)'
[233](https://github.com/red-data-tools/opencv-glib/runs/5416283947?check_suite_focus=true#step:4:233)
/usr/sbin/ld: /usr/lib/libvtkIOGeometry.so.1: undefined reference to `Json::Value::isDouble() const'
[234](https://github.com/red-data-tools/opencv-glib/runs/5416283947?check_suite_focus=true#step:4:234)
/usr/sbin/ld: /usr/lib/libvtkCommonDataModel.so.1: undefined reference to `pugi::xpath_node_set::end() const'
[235](https://github.com/red-data-tools/opencv-glib/runs/5416283947?check_suite_focus=true#step:4:235)
/usr/sbin/ld: /usr/lib/libvtkParallelMPI.so.1: undefined reference to `MPI_Gatherv'
[236](https://github.com/red-data-tools/opencv-glib/runs/5416283947?check_suite_focus=true#step:4:236)
/usr/sbin/ld: /usr/lib/libvtkIOGeometry.so.1: undefined reference to `Json::CharReaderBuilder::~CharReaderBuilder()'
[237](https://github.com/red-data-tools/opencv-glib/runs/5416283947?check_suite_focus=true#step:4:237)
/usr/sbin/ld: /usr/lib/libvtkParallelDIY.so.1: undefined reference to `MPI_Allgather'
[238](https://github.com/red-data-tools/opencv-glib/runs/5416283947?check_suite_focus=true#step:4:238)
/usr/sbin/ld: /usr/lib/libvtkCommonDataModel.so.1: undefined reference to `pugi::xml_node::append_copy(pugi::xml_node const&)'
[239](https://github.com/red-data-tools/opencv-glib/runs/5416283947?check_suite_focus=true#step:4:239)
/usr/sbin/ld: /usr/lib/libvtkIOGeometry.so.1: undefined reference to `Json::parseFromStream(Json::CharReader::Factory const&, std::istream&, Json::Value*, std::__cxx11::basic_string<char, std::char_traits<char>, std::allocator<char> >*)'
[240](https://github.com/red-data-tools/opencv-glib/runs/5416283947?check_suite_focus=true#step:4:240)
/usr/sbin/ld: /usr/lib/libvtkCommonDataModel.so.1: undefined reference to `pugi::xml_attribute_iterator::operator*() const'
[241](https://github.com/red-data-tools/opencv-glib/runs/5416283947?check_suite_focus=true#step:4:241)
/usr/sbin/ld: /usr/lib/libvtkParallelMPI.so.1: undefined reference to `ompi_mpi_long'
[242](https://github.com/red-data-tools/opencv-glib/runs/5416283947?check_suite_focus=true#step:4:242)
/usr/sbin/ld: /usr/lib/libvtkFiltersExtraction.so.1: undefined reference to `MPI_Isend'
[243](https://github.com/red-data-tools/opencv-glib/runs/5416283947?check_suite_focus=true#step:4:243)
/usr/sbin/ld: /usr/lib/libvtkCommonDataModel.so.1: undefined reference to `pugi::xml_named_node_iterator::operator++()'
[244](https://github.com/red-data-tools/opencv-glib/runs/5416283947?check_suite_focus=true#step:4:244)
/usr/sbin/ld: /usr/lib/libvtkCommonDataModel.so.1: undefined reference to `pugi::xml_document::save(std::ostream&, char const*, unsigned int, pugi::xml_encoding) const'
[245](https://github.com/red-data-tools/opencv-glib/runs/5416283947?check_suite_focus=true#step:4:245)
/usr/sbin/ld: /usr/lib/libvtkRenderingVtkJS.so.1: undefined reference to `Json::Value::Value(unsigned long)'
[246](https://github.com/red-data-tools/opencv-glib/runs/5416283947?check_suite_focus=true#step:4:246)
/usr/sbin/ld: /usr/lib/libvtkParallelMPI.so.1: undefined reference to `MPI_Finalize'
[247](https://github.com/red-data-tools/opencv-glib/runs/5416283947?check_suite_focus=true#step:4:247)
/usr/sbin/ld: /usr/lib/libvtkIOImage.so.1: undefined reference to `pugi::xml_document::~xml_document()'
[248](https://github.com/red-data-tools/opencv-glib/runs/5416283947?check_suite_focus=true#step:4:248)
/usr/sbin/ld: /usr/lib/libvtkCommonDataModel.so.1: undefined reference to `pugi::xml_node::path[abi:cxx11](char) const'
[249](https://github.com/red-data-tools/opencv-glib/runs/5416283947?check_suite_focus=true#step:4:249)
/usr/sbin/ld: /usr/lib/libvtkIOExport.so.1: undefined reference to `Json::Value::Value(long)'
[250](https://github.com/red-data-tools/opencv-glib/runs/5416283947?check_suite_focus=true#step:4:250)
/usr/sbin/ld: /usr/lib/libvtkParallelMPI.so.1: undefined reference to `ompi_mpi_op_sum'
[251](https://github.com/red-data-tools/opencv-glib/runs/5416283947?check_suite_focus=true#step:4:251)
/usr/sbin/ld: /usr/lib/libvtkParallelMPI.so.1: undefined reference to `MPI_Gather'
[252](https://github.com/red-data-tools/opencv-glib/runs/5416283947?check_suite_focus=true#step:4:252)
/usr/sbin/ld: /usr/lib/libvtkIOExport.so.1: undefined reference to `Json::Value::Value(char const*)'
[253](https://github.com/red-data-tools/opencv-glib/runs/5416283947?check_suite_focus=true#step:4:253)
/usr/sbin/ld: /usr/lib/libvtkIOGeometry.so.1: undefined reference to `Json::Value::Value(std::__cxx11::basic_string<char, std::char_traits<char>, std::allocator<char> > const&)'
[254](https://github.com/red-data-tools/opencv-glib/runs/5416283947?check_suite_focus=true#step:4:254)
/usr/sbin/ld: /usr/lib/libvtkParallelMPI.so.1: undefined reference to `ompi_mpi_op_lor'
[255](https://github.com/red-data-tools/opencv-glib/runs/5416283947?check_suite_focus=true#step:4:255)
/usr/sbin/ld: /usr/lib/libvtkFiltersExtraction.so.1: undefined reference to `ompi_mpi_comm_null'
[256](https://github.com/red-data-tools/opencv-glib/runs/5416283947?check_suite_focus=true#step:4:256)
collect2: error: ld returned 1 exit status
[257](https://github.com/red-data-tools/opencv-glib/runs/5416283947?check_suite_focus=true#step:4:257)
linking of temporary binary failed: Command '['gcc', '-pthread', '-o', '/home/opencv-glib/opencv-glib.build/tmp-introspect4re1m77m/CV-1.0', '/home/opencv-glib/opencv-glib.build/tmp-introspect4re1m77m/CV-1.0.o', '-L.', '-Wl,-rpath,.', '-Wl,--no-as-needed', '-L/home/opencv-glib/opencv-glib.build/opencv-glib', '-Wl,-rpath,/home/opencv-glib/opencv-glib.build/opencv-glib', '-lopencv-glib', '-lopencv_gapi', '-lopencv_stitching', '-lopencv_alphamat', '-lopencv_aruco', '-lopencv_barcode', '-lopencv_bgsegm', '-lopencv_bioinspired', '-lopencv_ccalib', '-lopencv_cvv', '-lopencv_dnn_objdetect', '-lopencv_dnn_superres', '-lopencv_dpm', '-lopencv_face', '-lopencv_freetype', '-lopencv_fuzzy', '-lopencv_hdf', '-lopencv_hfs', '-lopencv_img_hash', '-lopencv_intensity_transform', '-lopencv_line_descriptor', '-lopencv_mcc', '-lopencv_quality', '-lopencv_rapid', '-lopencv_reg', '-lopencv_rgbd', '-lopencv_saliency', '-lopencv_stereo', '-lopencv_structured_light', '-lopencv_phase_unwrapping', '-lopencv_superres', '-lopencv_optflow', '-lopencv_surface_matching', '-lopencv_tracking', '-lopencv_highgui', '-lopencv_datasets', '-lopencv_text', '-lopencv_plot', '-lopencv_videostab', '-lopencv_videoio', '-lopencv_viz', '-lopencv_wechat_qrcode', '-lopencv_xfeatures2d', '-lopencv_shape', '-lopencv_ml', '-lopencv_ximgproc', '-lopencv_video', '-lopencv_xobjdetect', '-lopencv_objdetect', '-lopencv_calib3d', '-lopencv_imgcodecs', '-lopencv_features2d', '-lopencv_dnn', '-lopencv_flann', '-lopencv_xphoto', '-lopencv_photo', '-lopencv_imgproc', '-lopencv_core', '-lgobject-2.0', '-lglib-2.0', '-lgirepository-1.0', '-lgio-2.0', '-lgobject-2.0', '-Wl,--export-dynamic', '-lgmodule-2.0', '-pthread', '-lglib-2.0', '-lglib-2.0']' returned non-zero exit status 1.
[258](https://github.com/red-data-tools/opencv-glib/runs/5416283947?check_suite_focus=true#step:4:258)
```